### PR TITLE
Add TaleTree landing pages and signup with companion selection

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -43,6 +43,7 @@ const App = () => (
           />
           <Route path="/taletree" element={<TaleTreeLanding />} />
           <Route path="/taletree-exact" element={<TaleTreeExact />} />
+          <Route path="/signup" element={<Signup />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -16,6 +16,7 @@ import EtherealPortalDemo from "./pages/EtherealPortalDemo";
 import ExactPortalDemo from "./pages/ExactPortalDemo";
 import VerticalArchDemo from "./pages/VerticalArchDemo";
 import MagicalPortalNewDemo from "./pages/MagicalPortalNewDemo";
+import TaleTreeLanding from "./pages/TaleTreeLanding";
 
 const queryClient = new QueryClient();
 

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -18,6 +18,7 @@ import VerticalArchDemo from "./pages/VerticalArchDemo";
 import MagicalPortalNewDemo from "./pages/MagicalPortalNewDemo";
 import TaleTreeLanding from "./pages/TaleTreeLanding";
 import TaleTreeExact from "./pages/TaleTreeExact";
+import Signup from "./pages/Signup";
 
 const queryClient = new QueryClient();
 

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -17,6 +17,7 @@ import ExactPortalDemo from "./pages/ExactPortalDemo";
 import VerticalArchDemo from "./pages/VerticalArchDemo";
 import MagicalPortalNewDemo from "./pages/MagicalPortalNewDemo";
 import TaleTreeLanding from "./pages/TaleTreeLanding";
+import TaleTreeExact from "./pages/TaleTreeExact";
 
 const queryClient = new QueryClient();
 

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -39,6 +39,7 @@ const App = () => (
             path="/new-magical-portal"
             element={<MagicalPortalNewDemo />}
           />
+          <Route path="/taletree" element={<TaleTreeLanding />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -41,6 +41,7 @@ const App = () => (
             element={<MagicalPortalNewDemo />}
           />
           <Route path="/taletree" element={<TaleTreeLanding />} />
+          <Route path="/taletree-exact" element={<TaleTreeExact />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -378,7 +378,7 @@ export function SimplifiedChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-[-80px] left-1/2">
+          <div className="absolute bottom-[-20px] left-1/2">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -317,7 +317,7 @@ export function SimplifiedChatContainer({
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
       {/* Fixed Companion Character grounded on landscape */}
-      <div className="absolute bottom-4 left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -288,7 +288,7 @@ export function SimplifiedChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-[-80px] left-1/2" key={message.id}>
+        <div className="absolute bottom-[-20px] left-1/2" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -288,7 +288,7 @@ export function SimplifiedChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-56 left-1/2" key={message.id}>
+        <div className="absolute bottom-[-80px] left-1/2" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -317,7 +317,7 @@ export function SimplifiedChatContainer({
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
       {/* Fixed Companion Character grounded on landscape */}
-      <div className="absolute bottom-[-120px] left-1/2 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      <div className="absolute bottom-[-80px] left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -317,7 +317,7 @@ export function SimplifiedChatContainer({
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
       {/* Fixed Companion Character grounded on landscape */}
-      <div className="absolute bottom-[-80px] left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      <div className="absolute bottom-[-150px] left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -378,7 +378,7 @@ export function SimplifiedChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-56 left-1/2">
+          <div className="absolute bottom-[-80px] left-1/2">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -317,7 +317,7 @@ export function SimplifiedChatContainer({
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
       {/* Fixed Companion Character grounded on landscape */}
-      <div className="absolute bottom-[-50px] left-1/2 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      <div className="absolute bottom-[-120px] left-1/2 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/SimplifiedChatContainer.tsx
+++ b/client/components/SimplifiedChatContainer.tsx
@@ -317,7 +317,7 @@ export function SimplifiedChatContainer({
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
       {/* Fixed Companion Character grounded on landscape */}
-      <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      <div className="absolute bottom-[-50px] left-1/2 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/signup/BunnyCharacter.tsx
+++ b/client/components/signup/BunnyCharacter.tsx
@@ -1,0 +1,26 @@
+const BunnyCharacter = () => {
+  return (
+    <div className="relative z-10 mb-8 animate-gentle-float">
+      <div className="w-32 h-40 relative">
+        {/* Bunny Body */}
+        <div className="w-20 h-24 bg-green-400 rounded-full mx-auto"></div>
+        {/* Bunny Head */}
+        <div className="w-16 h-16 bg-green-400 rounded-full mx-auto -mt-4 relative">
+          {/* Ears */}
+          <div className="absolute -top-6 left-2 w-3 h-8 bg-green-400 rounded-full rotate-12"></div>
+          <div className="absolute -top-6 right-2 w-3 h-8 bg-green-400 rounded-full -rotate-12"></div>
+          {/* Eyes */}
+          <div className="absolute top-4 left-3 w-2 h-2 bg-black rounded-full"></div>
+          <div className="absolute top-4 right-3 w-2 h-2 bg-black rounded-full"></div>
+          {/* Mouth */}
+          <div className="absolute top-7 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-black rounded-full"></div>
+        </div>
+        {/* Arms */}
+        <div className="absolute top-6 -left-3 w-6 h-12 bg-green-400 rounded-full rotate-12"></div>
+        <div className="absolute top-6 -right-3 w-6 h-12 bg-green-400 rounded-full -rotate-12"></div>
+      </div>
+    </div>
+  );
+};
+
+export default BunnyCharacter;

--- a/client/components/signup/CompanionSelectionModal.tsx
+++ b/client/components/signup/CompanionSelectionModal.tsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+interface CompanionAction {
+  id: string;
+  icon: string;
+  label: string;
+  color: string;
+  description: string;
+  position: { top: string; left: string };
+}
+
+interface CompanionSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectCompanion?: (companionId: string) => void;
+}
+
+export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: CompanionSelectionModalProps) {
+  const [hoveredCompanion, setHoveredCompanion] = useState<string | null>(null);
+
+  // Calculate circular positions using trigonometry
+  const radius = 150; // Radius of the circle
+  const centerX = 0; // Center X (will be positioned relative to container center)
+  const centerY = 0; // Center Y (will be positioned relative to container center)
+  
+  const companionActions: CompanionAction[] = [
+    {
+      id: "letsgo",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F2a5ef44c7f3d49488cc73782bdf5cec4?format=webp&width=800",
+      label: "Letsgo",
+      color: "bg-green-500",
+      description: "A friendly and energetic companion ready for adventures.",
+      position: { 
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/2)}px)` 
+      }
+    },
+    {
+      id: "rushmore",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fefc21cd16d284b21ae39c01cc9545eea?format=webp&width=800",
+      label: "Rushmore",
+      color: "bg-blue-500",
+      description: "A wise and thoughtful companion who loves to explore knowledge.",
+      position: { 
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/6)}px)` 
+      }
+    },
+    {
+      id: "uni",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fa67f6869fc244a548d248a492972e349?format=webp&width=800",
+      label: "Uni",
+      color: "bg-pink-500",
+      description: "A magical and creative companion with a love for imagination.",
+      position: { 
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/6)}px)` 
+      }
+    },
+    {
+      id: "cody",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc9b30794969246aabdd31eadd2637e37?format=webp&width=800",
+      label: "Cody",
+      color: "bg-red-500",
+      description: "A brave and determined companion ready for any challenge.",
+      position: { 
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/2)}px)` 
+      }
+    },
+    {
+      id: "doma",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fbc6b5df32a65496fbe94ca05152cd7b5?format=webp&width=800",
+      label: "Doma",
+      color: "bg-cyan-500",
+      description: "A calm and peaceful companion who brings tranquility.",
+      position: { 
+        top: `calc(50% + ${centerY + radius * Math.sin(5*Math.PI/6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos(5*Math.PI/6)}px)` 
+      }
+    },
+    {
+      id: "rooty",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F36e00ba92ccc4d928f7769dfccf431c9?format=webp&width=800",
+      label: "Rooty",
+      color: "bg-orange-500",
+      description: "A grounded and nurturing companion connected to nature.",
+      position: { 
+        top: `calc(50% + ${centerY + radius * Math.sin(-5*Math.PI/6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos(-5*Math.PI/6)}px)` 
+      }
+    }
+  ];
+
+  const getHoveredCompanion = () => {
+    return companionActions.find(companion => companion.id === hoveredCompanion);
+  };
+
+  const handleCompanionSelect = (companionId: string) => {
+    onSelectCompanion?.(companionId);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  const modalContent = (
+    <div 
+      className="fixed top-0 left-0 w-full h-full z-[99999] flex items-center justify-center backdrop-blur-md bg-black/40"
+      onClick={onClose}
+      style={{ zIndex: 99999 }}
+    >
+      {/* Modal Content */}
+      <div 
+        className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col p-4 relative z-[99999]"
+        onClick={(e) => e.stopPropagation()}
+        style={{ zIndex: 99999 }}
+      >
+          {/* Header */}
+          <div className="flex justify-center items-center mb-6">
+            <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
+              TaleTree Friends
+            </span>
+          </div>
+
+          {/* Wheel Container */}
+          <div className="flex-1 relative flex items-center justify-center">
+            {/* Center Close Button */}
+            <button
+              onClick={onClose}
+              className="absolute w-16 h-16 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200 shadow-lg z-20"
+              style={{
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)"
+              }}
+            >
+              <X className="w-8 h-8 text-white" />
+            </button>
+
+            {/* Companion Items - Circular Layout */}
+            {companionActions.map((companion) => (
+              <div
+                key={companion.id}
+                className="absolute cursor-pointer"
+                style={{
+                  top: companion.position.top,
+                  left: companion.position.left,
+                  transform: "translate(-50%, -50%)"
+                }}
+                onMouseEnter={() => setHoveredCompanion(companion.id)}
+                onMouseLeave={() => setHoveredCompanion(null)}
+                onClick={() => handleCompanionSelect(companion.id)}
+              >
+                <div className="flex flex-col items-center">
+                  {/* Companion Icon */}
+                  <div className="flex items-center justify-center hover:scale-110 transition-transform duration-200">
+                    <img 
+                      src={companion.icon} 
+                      alt={companion.label}
+                      className="w-16 h-16 object-contain"
+                    />
+                  </div>
+                  {/* Label */}
+                  <span className={`text-white text-sm font-medium mt-2 ${companion.color} px-3 py-1 rounded-full`}>
+                    {companion.label}
+                  </span>
+                </div>
+              </div>
+            ))}
+
+            {/* Hover Description */}
+            {hoveredCompanion && (
+              <div 
+                className="absolute z-30 transition-opacity duration-150 ease-in-out opacity-100"
+                style={{
+                  top: `calc(${getHoveredCompanion()?.position.top} - 80px)`,
+                  left: getHoveredCompanion()?.position.left,
+                  transform: "translate(-50%, 0)",
+                  pointerEvents: 'none'
+                }}
+              >
+                <div className={`${getHoveredCompanion()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}>
+                  <p className="text-xs leading-relaxed">
+                    {getHoveredCompanion()?.description}
+                  </p>
+                  {/* Tooltip arrow with matching color */}
+                  <div 
+                    className={`absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent`}
+                    style={{
+                      borderTopColor: getHoveredCompanion()?.color === 'bg-orange-500' ? '#f97316' :
+                                    getHoveredCompanion()?.color === 'bg-blue-500' ? '#3b82f6' :
+                                    getHoveredCompanion()?.color === 'bg-cyan-500' ? '#06b6d4' :
+                                    getHoveredCompanion()?.color === 'bg-green-500' ? '#22c55e' :
+                                    getHoveredCompanion()?.color === 'bg-red-500' ? '#ef4444' :
+                                    getHoveredCompanion()?.color === 'bg-pink-500' ? '#ec4899' : '#ec4899'
+                    }}
+                  ></div>
+                </div>
+              </div>
+            )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+}

--- a/client/components/signup/CompanionSelectionModal.tsx
+++ b/client/components/signup/CompanionSelectionModal.tsx
@@ -28,68 +28,68 @@ export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: 
   const companionActions: CompanionAction[] = [
     {
       id: "letsgo",
-      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F2a5ef44c7f3d49488cc73782bdf5cec4?format=webp&width=800",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
       label: "Letsgo",
       color: "bg-green-500",
       description: "A friendly and energetic companion ready for adventures.",
-      position: { 
+      position: {
         top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/2)}px)`, // -90° (top)
-        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/2)}px)` 
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/2)}px)`
       }
     },
     {
       id: "rushmore",
-      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fefc21cd16d284b21ae39c01cc9545eea?format=webp&width=800",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800",
       label: "Rushmore",
       color: "bg-blue-500",
       description: "A wise and thoughtful companion who loves to explore knowledge.",
-      position: { 
+      position: {
         top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/6)}px)`, // -30° (top right)
-        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/6)}px)` 
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/6)}px)`
       }
     },
     {
       id: "uni",
-      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fa67f6869fc244a548d248a492972e349?format=webp&width=800",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800",
       label: "Uni",
       color: "bg-pink-500",
       description: "A magical and creative companion with a love for imagination.",
-      position: { 
+      position: {
         top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/6)}px)`, // 30° (bottom right)
-        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/6)}px)` 
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/6)}px)`
       }
     },
     {
       id: "cody",
-      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc9b30794969246aabdd31eadd2637e37?format=webp&width=800",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800",
       label: "Cody",
       color: "bg-red-500",
       description: "A brave and determined companion ready for any challenge.",
-      position: { 
+      position: {
         top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/2)}px)`, // 90° (bottom)
-        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/2)}px)` 
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/2)}px)`
       }
     },
     {
       id: "doma",
-      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fbc6b5df32a65496fbe94ca05152cd7b5?format=webp&width=800",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800",
       label: "Doma",
       color: "bg-cyan-500",
       description: "A calm and peaceful companion who brings tranquility.",
-      position: { 
+      position: {
         top: `calc(50% + ${centerY + radius * Math.sin(5*Math.PI/6)}px)`, // 150° (bottom left)
-        left: `calc(50% + ${centerX + radius * Math.cos(5*Math.PI/6)}px)` 
+        left: `calc(50% + ${centerX + radius * Math.cos(5*Math.PI/6)}px)`
       }
     },
     {
       id: "rooty",
-      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F36e00ba92ccc4d928f7769dfccf431c9?format=webp&width=800",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800",
       label: "Rooty",
       color: "bg-orange-500",
       description: "A grounded and nurturing companion connected to nature.",
-      position: { 
+      position: {
         top: `calc(50% + ${centerY + radius * Math.sin(-5*Math.PI/6)}px)`, // -150° (top left)
-        left: `calc(50% + ${centerX + radius * Math.cos(-5*Math.PI/6)}px)` 
+        left: `calc(50% + ${centerX + radius * Math.cos(-5*Math.PI/6)}px)`
       }
     }
   ];

--- a/client/components/signup/CompanionSelectionModal.tsx
+++ b/client/components/signup/CompanionSelectionModal.tsx
@@ -17,14 +17,18 @@ interface CompanionSelectionModalProps {
   onSelectCompanion?: (companionId: string) => void;
 }
 
-export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: CompanionSelectionModalProps) {
+export function CompanionSelectionModal({
+  isOpen,
+  onClose,
+  onSelectCompanion,
+}: CompanionSelectionModalProps) {
   const [hoveredCompanion, setHoveredCompanion] = useState<string | null>(null);
 
   // Calculate circular positions using trigonometry
   const radius = 150; // Radius of the circle
   const centerX = 0; // Center X (will be positioned relative to container center)
   const centerY = 0; // Center Y (will be positioned relative to container center)
-  
+
   const companionActions: CompanionAction[] = [
     {
       id: "letsgo",
@@ -33,31 +37,33 @@ export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: 
       color: "bg-green-500",
       description: "A friendly and energetic companion ready for adventures.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/2)}px)`, // -90° (top)
-        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/2)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 2)}px)`,
+      },
     },
     {
       id: "rushmore",
       icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800",
       label: "Rushmore",
       color: "bg-blue-500",
-      description: "A wise and thoughtful companion who loves to explore knowledge.",
+      description:
+        "A wise and thoughtful companion who loves to explore knowledge.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/6)}px)`, // -30° (top right)
-        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/6)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 6)}px)`,
+      },
     },
     {
       id: "uni",
       icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800",
       label: "Uni",
       color: "bg-pink-500",
-      description: "A magical and creative companion with a love for imagination.",
+      description:
+        "A magical and creative companion with a love for imagination.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/6)}px)`, // 30° (bottom right)
-        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/6)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 6)}px)`,
+      },
     },
     {
       id: "cody",
@@ -66,9 +72,9 @@ export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: 
       color: "bg-red-500",
       description: "A brave and determined companion ready for any challenge.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/2)}px)`, // 90° (bottom)
-        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/2)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 2)}px)`,
+      },
     },
     {
       id: "doma",
@@ -77,9 +83,9 @@ export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: 
       color: "bg-cyan-500",
       description: "A calm and peaceful companion who brings tranquility.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(5*Math.PI/6)}px)`, // 150° (bottom left)
-        left: `calc(50% + ${centerX + radius * Math.cos(5*Math.PI/6)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin((5 * Math.PI) / 6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos((5 * Math.PI) / 6)}px)`,
+      },
     },
     {
       id: "rooty",
@@ -88,14 +94,16 @@ export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: 
       color: "bg-orange-500",
       description: "A grounded and nurturing companion connected to nature.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(-5*Math.PI/6)}px)`, // -150° (top left)
-        left: `calc(50% + ${centerX + radius * Math.cos(-5*Math.PI/6)}px)`
-      }
-    }
+        top: `calc(50% + ${centerY + radius * Math.sin((-5 * Math.PI) / 6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos((-5 * Math.PI) / 6)}px)`,
+      },
+    },
   ];
 
   const getHoveredCompanion = () => {
-    return companionActions.find(companion => companion.id === hoveredCompanion);
+    return companionActions.find(
+      (companion) => companion.id === hoveredCompanion,
+    );
   };
 
   const handleCompanionSelect = (companionId: string) => {
@@ -106,100 +114,112 @@ export function CompanionSelectionModal({ isOpen, onClose, onSelectCompanion }: 
   if (!isOpen) return null;
 
   const modalContent = (
-    <div 
+    <div
       className="fixed top-0 left-0 w-full h-full z-[99999] flex items-center justify-center backdrop-blur-md bg-black/40"
       onClick={onClose}
       style={{ zIndex: 99999 }}
     >
       {/* Modal Content */}
-      <div 
+      <div
         className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col p-4 relative z-[99999]"
         onClick={(e) => e.stopPropagation()}
         style={{ zIndex: 99999 }}
       >
-          {/* Header */}
-          <div className="flex justify-center items-center mb-6">
-            <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
-              TaleTree Friends
-            </span>
-          </div>
+        {/* Header */}
+        <div className="flex justify-center items-center mb-6">
+          <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
+            TaleTree Friends
+          </span>
+        </div>
 
-          {/* Wheel Container */}
-          <div className="flex-1 relative flex items-center justify-center">
-            {/* Center Close Button */}
-            <button
-              onClick={onClose}
-              className="absolute w-16 h-16 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200 shadow-lg z-20"
+        {/* Wheel Container */}
+        <div className="flex-1 relative flex items-center justify-center">
+          {/* Center Close Button */}
+          <button
+            onClick={onClose}
+            className="absolute w-16 h-16 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200 shadow-lg z-20"
+            style={{
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+            }}
+          >
+            <X className="w-8 h-8 text-white" />
+          </button>
+
+          {/* Companion Items - Circular Layout */}
+          {companionActions.map((companion) => (
+            <div
+              key={companion.id}
+              className="absolute cursor-pointer"
               style={{
-                top: "50%",
-                left: "50%",
-                transform: "translate(-50%, -50%)"
+                top: companion.position.top,
+                left: companion.position.left,
+                transform: "translate(-50%, -50%)",
+              }}
+              onMouseEnter={() => setHoveredCompanion(companion.id)}
+              onMouseLeave={() => setHoveredCompanion(null)}
+              onClick={() => handleCompanionSelect(companion.id)}
+            >
+              <div className="flex flex-col items-center">
+                {/* Companion Icon */}
+                <div className="flex items-center justify-center hover:scale-110 transition-transform duration-200">
+                  <img
+                    src={companion.icon}
+                    alt={companion.label}
+                    className="w-16 h-16 object-contain"
+                  />
+                </div>
+                {/* Label */}
+                <span
+                  className={`text-white text-sm font-medium mt-2 ${companion.color} px-3 py-1 rounded-full`}
+                >
+                  {companion.label}
+                </span>
+              </div>
+            </div>
+          ))}
+
+          {/* Hover Description */}
+          {hoveredCompanion && (
+            <div
+              className="absolute z-30 transition-opacity duration-150 ease-in-out opacity-100"
+              style={{
+                top: `calc(${getHoveredCompanion()?.position.top} - 80px)`,
+                left: getHoveredCompanion()?.position.left,
+                transform: "translate(-50%, 0)",
+                pointerEvents: "none",
               }}
             >
-              <X className="w-8 h-8 text-white" />
-            </button>
-
-            {/* Companion Items - Circular Layout */}
-            {companionActions.map((companion) => (
               <div
-                key={companion.id}
-                className="absolute cursor-pointer"
-                style={{
-                  top: companion.position.top,
-                  left: companion.position.left,
-                  transform: "translate(-50%, -50%)"
-                }}
-                onMouseEnter={() => setHoveredCompanion(companion.id)}
-                onMouseLeave={() => setHoveredCompanion(null)}
-                onClick={() => handleCompanionSelect(companion.id)}
+                className={`${getHoveredCompanion()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}
               >
-                <div className="flex flex-col items-center">
-                  {/* Companion Icon */}
-                  <div className="flex items-center justify-center hover:scale-110 transition-transform duration-200">
-                    <img 
-                      src={companion.icon} 
-                      alt={companion.label}
-                      className="w-16 h-16 object-contain"
-                    />
-                  </div>
-                  {/* Label */}
-                  <span className={`text-white text-sm font-medium mt-2 ${companion.color} px-3 py-1 rounded-full`}>
-                    {companion.label}
-                  </span>
-                </div>
+                <p className="text-xs leading-relaxed">
+                  {getHoveredCompanion()?.description}
+                </p>
+                {/* Tooltip arrow with matching color */}
+                <div
+                  className={`absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent`}
+                  style={{
+                    borderTopColor:
+                      getHoveredCompanion()?.color === "bg-orange-500"
+                        ? "#f97316"
+                        : getHoveredCompanion()?.color === "bg-blue-500"
+                          ? "#3b82f6"
+                          : getHoveredCompanion()?.color === "bg-cyan-500"
+                            ? "#06b6d4"
+                            : getHoveredCompanion()?.color === "bg-green-500"
+                              ? "#22c55e"
+                              : getHoveredCompanion()?.color === "bg-red-500"
+                                ? "#ef4444"
+                                : getHoveredCompanion()?.color === "bg-pink-500"
+                                  ? "#ec4899"
+                                  : "#ec4899",
+                  }}
+                ></div>
               </div>
-            ))}
-
-            {/* Hover Description */}
-            {hoveredCompanion && (
-              <div 
-                className="absolute z-30 transition-opacity duration-150 ease-in-out opacity-100"
-                style={{
-                  top: `calc(${getHoveredCompanion()?.position.top} - 80px)`,
-                  left: getHoveredCompanion()?.position.left,
-                  transform: "translate(-50%, 0)",
-                  pointerEvents: 'none'
-                }}
-              >
-                <div className={`${getHoveredCompanion()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}>
-                  <p className="text-xs leading-relaxed">
-                    {getHoveredCompanion()?.description}
-                  </p>
-                  {/* Tooltip arrow with matching color */}
-                  <div 
-                    className={`absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent`}
-                    style={{
-                      borderTopColor: getHoveredCompanion()?.color === 'bg-orange-500' ? '#f97316' :
-                                    getHoveredCompanion()?.color === 'bg-blue-500' ? '#3b82f6' :
-                                    getHoveredCompanion()?.color === 'bg-cyan-500' ? '#06b6d4' :
-                                    getHoveredCompanion()?.color === 'bg-green-500' ? '#22c55e' :
-                                    getHoveredCompanion()?.color === 'bg-red-500' ? '#ef4444' :
-                                    getHoveredCompanion()?.color === 'bg-pink-500' ? '#ec4899' : '#ec4899'
-                    }}
-                  ></div>
-                </div>
-              </div>
-            )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/client/components/signup/CreativitySection.tsx
+++ b/client/components/signup/CreativitySection.tsx
@@ -1,0 +1,20 @@
+const CreativitySection = () => {
+  return (
+    <div className="px-8 py-8 text-center">
+      <p className="text-gray-700 mb-2">
+        <span className="font-semibold">
+          Creativity and kindness matter more than score
+        </span>{" "}
+        in the age of
+        <span className="inline-flex items-center mx-1 px-2 py-1 bg-purple-100 text-purple-800 rounded text-sm">
+          AI
+        </span>
+      </p>
+      <p className="text-gray-600">
+        TaleTree helps your child grow both — and get rewarded for it.
+      </p>
+    </div>
+  );
+};
+
+export default CreativitySection;

--- a/client/components/signup/DecorativeStars.tsx
+++ b/client/components/signup/DecorativeStars.tsx
@@ -1,12 +1,15 @@
 const DecorativeStars = () => {
   return (
-    <div className="absolute inset-0 overflow-hidden">
-      <div className="absolute top-20 left-10 w-2 h-2 bg-pink-400 rounded-full animate-pulse"></div>
-      <div className="absolute top-32 right-20 w-1 h-1 bg-yellow-400 rounded-full animate-pulse"></div>
-      <div className="absolute top-16 right-32 w-3 h-3 bg-orange-400 rounded-full animate-pulse"></div>
-      <div className="absolute top-40 left-32 w-2 h-2 bg-purple-400 rounded-full animate-pulse"></div>
-      <div className="absolute top-24 left-1/3 w-1 h-1 bg-cyan-400 rounded-full animate-pulse"></div>
-      <div className="absolute top-28 right-1/4 w-2 h-2 bg-pink-300 rounded-full animate-pulse"></div>
+    <div className="absolute inset-0 overflow-hidden pointer-events-none z-5">
+      <div className="absolute top-20 left-10 w-2 h-2 bg-pink-400 rounded-full animate-pulse opacity-70"></div>
+      <div className="absolute top-32 right-20 w-1 h-1 bg-yellow-400 rounded-full animate-pulse opacity-80"></div>
+      <div className="absolute top-16 right-32 w-3 h-3 bg-orange-400 rounded-full animate-pulse opacity-60"></div>
+      <div className="absolute top-40 left-32 w-2 h-2 bg-purple-400 rounded-full animate-pulse opacity-75"></div>
+      <div className="absolute top-24 left-1/3 w-1 h-1 bg-cyan-400 rounded-full animate-pulse opacity-90"></div>
+      <div className="absolute top-28 right-1/4 w-2 h-2 bg-pink-300 rounded-full animate-pulse opacity-65"></div>
+      <div className="absolute top-60 left-1/4 w-1 h-1 bg-blue-400 rounded-full animate-pulse opacity-80"></div>
+      <div className="absolute top-12 left-1/2 w-2 h-2 bg-green-400 rounded-full animate-pulse opacity-70"></div>
+      <div className="absolute top-48 right-1/3 w-1 h-1 bg-red-400 rounded-full animate-pulse opacity-85"></div>
     </div>
   );
 };

--- a/client/components/signup/DecorativeStars.tsx
+++ b/client/components/signup/DecorativeStars.tsx
@@ -1,0 +1,14 @@
+const DecorativeStars = () => {
+  return (
+    <div className="absolute inset-0 overflow-hidden">
+      <div className="absolute top-20 left-10 w-2 h-2 bg-pink-400 rounded-full animate-pulse"></div>
+      <div className="absolute top-32 right-20 w-1 h-1 bg-yellow-400 rounded-full animate-pulse"></div>
+      <div className="absolute top-16 right-32 w-3 h-3 bg-orange-400 rounded-full animate-pulse"></div>
+      <div className="absolute top-40 left-32 w-2 h-2 bg-purple-400 rounded-full animate-pulse"></div>
+      <div className="absolute top-24 left-1/3 w-1 h-1 bg-cyan-400 rounded-full animate-pulse"></div>
+      <div className="absolute top-28 right-1/4 w-2 h-2 bg-pink-300 rounded-full animate-pulse"></div>
+    </div>
+  );
+};
+
+export default DecorativeStars;

--- a/client/components/signup/EducatorsSection.tsx
+++ b/client/components/signup/EducatorsSection.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+const EducatorsSection = () => {
+  return (
+    <div className="px-8 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-xl font-semibold text-gray-900">
+          TaleTree for Educators
+        </h3>
+        <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+          View all
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <Card className="bg-gray-100 border-0">
+          <CardContent className="p-6">
+            <div className="w-full h-40 bg-gray-200 rounded mb-4"></div>
+            <p className="text-sm text-gray-700 mb-2">
+              Learn about what we offer
+            </p>
+            <p className="text-xs text-gray-500">Jan 24, 2024</p>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-gray-100 border-0">
+          <CardContent className="p-6">
+            <div className="w-full h-40 bg-gray-200 rounded mb-4"></div>
+            <p className="text-sm text-gray-700 mb-2">
+              The TaleTree Method
+            </p>
+            <p className="text-xs text-gray-500">Jan 24, 2024</p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default EducatorsSection;

--- a/client/components/signup/ExpertsSection.tsx
+++ b/client/components/signup/ExpertsSection.tsx
@@ -1,0 +1,32 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+const ExpertsSection = () => {
+  return (
+    <div className="px-8 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-xl font-semibold text-gray-900">
+          Experts and Brands
+        </h3>
+        <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+          View all
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} className="bg-gray-100 border-0">
+            <CardContent className="p-6">
+              <div className="w-full h-32 bg-gray-200 rounded mb-4"></div>
+              <p className="text-sm text-gray-700 mb-2">
+                Expert opinion piece
+              </p>
+              <p className="text-xs text-gray-500">Jan 24, 2024</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ExpertsSection;

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -21,7 +21,7 @@ export function HeaderActions() {
             <Search className="w-5 h-5 text-white" />
           </button>
         ) : (
-          <div className="bg-purple-600 backdrop-blur-sm border border-purple-500 rounded-full px-4 py-2 min-w-[240px] transition-all duration-300">
+          <div className="bg-transparent backdrop-blur-sm border border-white/40 rounded-full px-4 py-2 min-w-[240px] transition-all duration-300">
             <div className="flex items-center gap-2">
               <Search className="w-4 h-4 text-white" />
               <input

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -37,43 +37,45 @@ export function HeaderActions() {
       </div>
 
       {/* Login Component */}
-      <div 
-        className="relative"
-        onMouseEnter={() => setIsLoginMenuOpen(true)}
-        onMouseLeave={() => setIsLoginMenuOpen(false)}
-      >
-        <button className="border border-white/40 text-white px-4 py-2 rounded-full font-medium text-sm hover:bg-white hover:text-gray-800 transition-all duration-300 flex items-center gap-2">
-          <User className="w-4 h-4" />
-          Login
-        </button>
+      <div className="relative">
+        <div
+          onMouseEnter={() => setIsLoginMenuOpen(true)}
+          onMouseLeave={() => setIsLoginMenuOpen(false)}
+          className="relative"
+        >
+          <button className="border border-white/40 text-white px-4 py-2 rounded-full font-medium text-sm hover:bg-white hover:text-gray-800 transition-all duration-300 flex items-center gap-2">
+            <User className="w-4 h-4" />
+            Login
+          </button>
 
-        {/* Login Dropdown Menu */}
-        {isLoginMenuOpen && (
-          <div className="absolute top-full right-0 mt-2 bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden min-w-[140px] transition-all duration-300">
-            <div className="py-2">
-              <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
-                <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
-                  <div className="w-3 h-3 bg-white rounded-full"></div>
-                </div>
-                <span className="text-gray-800 font-medium text-sm">Kids</span>
-              </button>
-              
-              <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
-                <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
-                  <div className="w-3 h-3 bg-white rounded-full"></div>
-                </div>
-                <span className="text-gray-800 font-medium text-sm">Guardians</span>
-              </button>
-              
-              <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
-                <div className="w-6 h-6 bg-purple-500 rounded-full flex items-center justify-center">
-                  <div className="w-3 h-3 bg-white rounded-full"></div>
-                </div>
-                <span className="text-gray-800 font-medium text-sm">Educator</span>
-              </button>
+          {/* Login Dropdown Menu */}
+          {isLoginMenuOpen && (
+            <div className="absolute top-full right-0 mt-2 bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden min-w-[140px] transition-all duration-300">
+              <div className="py-2">
+                <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
+                  <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
+                    <div className="w-3 h-3 bg-white rounded-full"></div>
+                  </div>
+                  <span className="text-gray-800 font-medium text-sm">Kids</span>
+                </button>
+
+                <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
+                  <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
+                    <div className="w-3 h-3 bg-white rounded-full"></div>
+                  </div>
+                  <span className="text-gray-800 font-medium text-sm">Guardians</span>
+                </button>
+
+                <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
+                  <div className="w-6 h-6 bg-purple-500 rounded-full flex items-center justify-center">
+                    <div className="w-3 h-3 bg-white rounded-full"></div>
+                  </div>
+                  <span className="text-gray-800 font-medium text-sm">Educator</span>
+                </button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -37,20 +37,22 @@ export function HeaderActions() {
       </div>
 
       {/* Login Component */}
-      <div className="relative">
-        <div
-          onMouseEnter={() => setIsLoginMenuOpen(true)}
-          onMouseLeave={() => setIsLoginMenuOpen(false)}
-          className="relative"
-        >
-          <button className="border border-white/40 text-white px-4 py-2 rounded-full font-medium text-sm hover:bg-white hover:text-gray-800 transition-all duration-300 flex items-center gap-2">
-            <User className="w-4 h-4" />
-            Login
-          </button>
+      <div
+        className="relative"
+        onMouseEnter={() => setIsLoginMenuOpen(true)}
+        onMouseLeave={() => setIsLoginMenuOpen(false)}
+      >
+        <button className="border border-white/40 text-white px-4 py-2 rounded-full font-medium text-sm hover:bg-white hover:text-gray-800 transition-all duration-300 flex items-center gap-2">
+          <User className="w-4 h-4" />
+          Login
+        </button>
 
-          {/* Login Dropdown Menu */}
-          {isLoginMenuOpen && (
-            <div className="absolute top-full right-0 mt-2 bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden min-w-[140px] transition-all duration-300">
+        {/* Login Dropdown Menu */}
+        {isLoginMenuOpen && (
+          <div className="absolute top-full right-0 pt-2">
+            {/* Invisible bridge to prevent menu from closing */}
+            <div className="absolute top-0 right-0 w-full h-2 bg-transparent"></div>
+            <div className="bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden min-w-[140px] transition-all duration-300">
               <div className="py-2">
                 <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
                   <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
@@ -74,8 +76,8 @@ export function HeaderActions() {
                 </button>
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -14,7 +14,7 @@ export function HeaderActions() {
         onMouseLeave={() => setIsSearchExpanded(false)}
       >
         {!isSearchExpanded ? (
-          <button className="w-10 h-10 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full flex items-center justify-center hover:bg-white/20 transition-all duration-300 cursor-pointer">
+          <button className="w-10 h-10 border border-white/40 rounded-full flex items-center justify-center hover:bg-white/10 transition-all duration-300 cursor-pointer">
             <Search className="w-5 h-5 text-white" />
           </button>
         ) : (

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -38,7 +38,7 @@ export function HeaderActions() {
         onMouseEnter={() => setIsLoginMenuOpen(true)}
         onMouseLeave={() => setIsLoginMenuOpen(false)}
       >
-        <button className="bg-white text-purple-800 px-4 py-2 rounded-full font-medium text-sm hover:bg-white/90 transition-all duration-300 flex items-center gap-2">
+        <button className="border border-white/40 text-white px-4 py-2 rounded-full font-medium text-sm hover:bg-white/10 transition-all duration-300 flex items-center gap-2">
           <User className="w-4 h-4" />
           Login
         </button>

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Search, User } from "lucide-react";
+
+export function HeaderActions() {
+  const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+  const [isLoginMenuOpen, setIsLoginMenuOpen] = useState(false);
+
+  return (
+    <div className="absolute top-6 right-6 z-50 flex items-center gap-4">
+      {/* Search Component */}
+      <div 
+        className="relative"
+        onMouseEnter={() => setIsSearchExpanded(true)}
+        onMouseLeave={() => setIsSearchExpanded(false)}
+      >
+        {!isSearchExpanded ? (
+          <button className="w-10 h-10 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full flex items-center justify-center hover:bg-white/20 transition-all duration-300 cursor-pointer">
+            <Search className="w-5 h-5 text-white" />
+          </button>
+        ) : (
+          <div className="bg-purple-800/90 backdrop-blur-sm border border-purple-600/30 rounded-full px-4 py-2 min-w-[200px] transition-all duration-300">
+            <div className="flex items-center gap-2">
+              <Search className="w-4 h-4 text-white/80" />
+              <input 
+                type="text"
+                placeholder="Search TaleTree"
+                className="bg-transparent text-white placeholder-white/70 border-none outline-none flex-1 text-sm"
+                autoFocus
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Login Component */}
+      <div 
+        className="relative"
+        onMouseEnter={() => setIsLoginMenuOpen(true)}
+        onMouseLeave={() => setIsLoginMenuOpen(false)}
+      >
+        <button className="bg-white text-purple-800 px-4 py-2 rounded-full font-medium text-sm hover:bg-white/90 transition-all duration-300 flex items-center gap-2">
+          <User className="w-4 h-4" />
+          Login
+        </button>
+
+        {/* Login Dropdown Menu */}
+        {isLoginMenuOpen && (
+          <div className="absolute top-full right-0 mt-2 bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden min-w-[140px] transition-all duration-300">
+            <div className="py-2">
+              <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
+                <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
+                  <div className="w-3 h-3 bg-white rounded-full"></div>
+                </div>
+                <span className="text-gray-800 font-medium text-sm">Kids</span>
+              </button>
+              
+              <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
+                <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
+                  <div className="w-3 h-3 bg-white rounded-full"></div>
+                </div>
+                <span className="text-gray-800 font-medium text-sm">Guardians</span>
+              </button>
+              
+              <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
+                <div className="w-6 h-6 bg-purple-500 rounded-full flex items-center justify-center">
+                  <div className="w-3 h-3 bg-white rounded-full"></div>
+                </div>
+                <span className="text-gray-800 font-medium text-sm">Educator</span>
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -38,7 +38,7 @@ export function HeaderActions() {
         onMouseEnter={() => setIsLoginMenuOpen(true)}
         onMouseLeave={() => setIsLoginMenuOpen(false)}
       >
-        <button className="border border-white/40 text-white px-4 py-2 rounded-full font-medium text-sm hover:bg-white/10 transition-all duration-300 flex items-center gap-2">
+        <button className="border border-white/40 text-white px-4 py-2 rounded-full font-medium text-sm hover:bg-white hover:text-gray-800 transition-all duration-300 flex items-center gap-2">
           <User className="w-4 h-4" />
           Login
         </button>

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -55,23 +55,29 @@ export function HeaderActions() {
             <div className="bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden min-w-[140px] transition-all duration-300">
               <div className="py-2">
                 <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
-                  <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
-                    <div className="w-3 h-3 bg-white rounded-full"></div>
-                  </div>
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F8ade38e9e3ed4481823af4c44b90eec8?format=webp&width=800"
+                    alt="Kids"
+                    className="w-6 h-6 rounded-full object-cover"
+                  />
                   <span className="text-gray-800 font-medium text-sm">Kids</span>
                 </button>
 
                 <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
-                  <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
-                    <div className="w-3 h-3 bg-white rounded-full"></div>
-                  </div>
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F70906b39ddd5462b8740ab078244aace?format=webp&width=800"
+                    alt="Parent"
+                    className="w-6 h-6 rounded-full object-cover"
+                  />
                   <span className="text-gray-800 font-medium text-sm">Guardians</span>
                 </button>
 
                 <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
-                  <div className="w-6 h-6 bg-purple-500 rounded-full flex items-center justify-center">
-                    <div className="w-3 h-3 bg-white rounded-full"></div>
-                  </div>
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F79afaa309c38474ba6bc9b0f00dbac56?format=webp&width=800"
+                    alt="Educator"
+                    className="w-6 h-6 rounded-full object-cover"
+                  />
                   <span className="text-gray-800 font-medium text-sm">Educator</span>
                 </button>
               </div>

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -60,7 +60,9 @@ export function HeaderActions() {
                     alt="Kids"
                     className="w-6 h-6 rounded-full object-cover"
                   />
-                  <span className="text-gray-800 font-medium text-sm">Kids</span>
+                  <span className="text-gray-800 font-medium text-sm">
+                    Kids
+                  </span>
                 </button>
 
                 <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
@@ -69,7 +71,9 @@ export function HeaderActions() {
                     alt="Parent"
                     className="w-6 h-6 rounded-full object-cover"
                   />
-                  <span className="text-gray-800 font-medium text-sm">Guardians</span>
+                  <span className="text-gray-800 font-medium text-sm">
+                    Guardians
+                  </span>
                 </button>
 
                 <button className="w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors duration-200 flex items-center gap-3">
@@ -78,7 +82,9 @@ export function HeaderActions() {
                     alt="Educator"
                     className="w-6 h-6 rounded-full object-cover"
                   />
-                  <span className="text-gray-800 font-medium text-sm">Educator</span>
+                  <span className="text-gray-800 font-medium text-sm">
+                    Educator
+                  </span>
                 </button>
               </div>
             </div>

--- a/client/components/signup/HeaderActions.tsx
+++ b/client/components/signup/HeaderActions.tsx
@@ -5,27 +5,31 @@ export function HeaderActions() {
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
   const [isLoginMenuOpen, setIsLoginMenuOpen] = useState(false);
 
+  const handleSearchClick = () => {
+    setIsSearchExpanded(!isSearchExpanded);
+  };
+
   return (
     <div className="absolute top-6 right-6 z-50 flex items-center gap-4">
       {/* Search Component */}
-      <div 
-        className="relative"
-        onMouseEnter={() => setIsSearchExpanded(true)}
-        onMouseLeave={() => setIsSearchExpanded(false)}
-      >
+      <div className="relative">
         {!isSearchExpanded ? (
-          <button className="w-10 h-10 border border-white/40 rounded-full flex items-center justify-center hover:bg-white/10 transition-all duration-300 cursor-pointer">
+          <button
+            onClick={handleSearchClick}
+            className="w-10 h-10 border border-white/40 rounded-full flex items-center justify-center hover:bg-white/10 transition-all duration-300 cursor-pointer"
+          >
             <Search className="w-5 h-5 text-white" />
           </button>
         ) : (
-          <div className="bg-purple-800/90 backdrop-blur-sm border border-purple-600/30 rounded-full px-4 py-2 min-w-[200px] transition-all duration-300">
+          <div className="bg-purple-600 backdrop-blur-sm border border-purple-500 rounded-full px-4 py-2 min-w-[240px] transition-all duration-300">
             <div className="flex items-center gap-2">
-              <Search className="w-4 h-4 text-white/80" />
-              <input 
+              <Search className="w-4 h-4 text-white" />
+              <input
                 type="text"
                 placeholder="Search TaleTree"
                 className="bg-transparent text-white placeholder-white/70 border-none outline-none flex-1 text-sm"
                 autoFocus
+                onBlur={() => setIsSearchExpanded(false)}
               />
             </div>
           </div>

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { SignupChatContainer } from "./SignupChatContainer";
-import { ChatInputBox } from "@/components/ChatInputBox";
+import { SignupChatInput } from "./SignupChatInput";
 
 const HeroSection = () => {
   const [chatMessages, setChatMessages] = useState<any[]>([

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { SimplifiedChatContainer } from "@/components/SimplifiedChatContainer";
+import { SignupChatContainer } from "./SignupChatContainer";
 import { ChatInputBox } from "@/components/ChatInputBox";
 
 const HeroSection = () => {

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,6 +1,11 @@
+import { useState } from "react";
 import { SimplifiedChatContainer } from "@/components/SimplifiedChatContainer";
+import SearchChatMessage from "./SearchChatMessage";
 
 const HeroSection = () => {
+  const [searchResults, setSearchResults] = useState<string[]>([]);
+  const [hasSearched, setHasSearched] = useState(false);
+
   // Sample messages for the chat container
   const sampleMessages = [
     {
@@ -11,6 +16,18 @@ const HeroSection = () => {
       timestamp: new Date(),
     }
   ];
+
+  const handleSearch = (query: string) => {
+    console.log("Searching for:", query);
+    setHasSearched(true);
+    // Simulate search results
+    const mockResults = [
+      `Creative stories about ${query}`,
+      `Educational content for ${query}`,
+      `Interactive activities with ${query}`,
+    ];
+    setSearchResults(mockResults);
+  };
 
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[80vh] px-4 overflow-hidden">
@@ -32,6 +49,33 @@ const HeroSection = () => {
           isAIThinking={false}
         />
       </div>
+
+      {/* Search using ChatMessage - positioned at bottom */}
+      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-md px-4">
+        <SearchChatMessage
+          onSearch={handleSearch}
+          placeholder="Ask me anything..."
+        />
+      </div>
+
+      {/* Search Results */}
+      {hasSearched && searchResults.length > 0 && (
+        <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-md px-4">
+          <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-4 shadow-lg border border-white/20">
+            <h4 className="text-sm font-bold text-purple-700 mb-2">Search Results:</h4>
+            <ul className="space-y-2">
+              {searchResults.map((result, index) => (
+                <li
+                  key={index}
+                  className="text-sm text-gray-700 p-2 bg-purple-50 rounded-lg hover:bg-purple-100 cursor-pointer transition-colors"
+                >
+                  {result}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,11 +1,6 @@
-import { useState } from "react";
 import { SimplifiedChatContainer } from "@/components/SimplifiedChatContainer";
-import SearchChatMessage from "./SearchChatMessage";
 
 const HeroSection = () => {
-  const [searchResults, setSearchResults] = useState<string[]>([]);
-  const [hasSearched, setHasSearched] = useState(false);
-
   // Sample messages for the chat container
   const sampleMessages = [
     {
@@ -16,18 +11,6 @@ const HeroSection = () => {
       timestamp: new Date(),
     }
   ];
-
-  const handleSearch = (query: string) => {
-    console.log("Searching for:", query);
-    setHasSearched(true);
-    // Simulate search results
-    const mockResults = [
-      `Creative stories about ${query}`,
-      `Educational content for ${query}`,
-      `Interactive activities with ${query}`,
-    ];
-    setSearchResults(mockResults);
-  };
 
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[80vh] px-4 overflow-hidden">
@@ -49,33 +32,6 @@ const HeroSection = () => {
           isAIThinking={false}
         />
       </div>
-
-      {/* Search using ChatMessage - positioned at bottom */}
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-md px-4">
-        <SearchChatMessage
-          onSearch={handleSearch}
-          placeholder="Ask me anything..."
-        />
-      </div>
-
-      {/* Search Results */}
-      {hasSearched && searchResults.length > 0 && (
-        <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-md px-4">
-          <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-4 shadow-lg border border-white/20">
-            <h4 className="text-sm font-bold text-purple-700 mb-2">Search Results:</h4>
-            <ul className="space-y-2">
-              {searchResults.map((result, index) => (
-                <li
-                  key={index}
-                  className="text-sm text-gray-700 p-2 bg-purple-50 rounded-lg hover:bg-purple-100 cursor-pointer transition-colors"
-                >
-                  {result}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -55,6 +55,26 @@ const HeroSection = () => {
       {/* Header Actions - Search and Login */}
       <HeaderActions />
 
+      {/* TaleTree Logo and Title */}
+      <div className="absolute top-12 left-1/2 transform -translate-x-1/2 z-40 text-center">
+        <div className="flex flex-col items-center">
+          {/* Logo */}
+          <div className="w-16 h-16 mb-4">
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
+              alt="TaleTree Logo"
+              className="w-full h-full object-contain"
+            />
+          </div>
+          {/* Title */}
+          <h1 className="text-white text-3xl md:text-4xl font-bold mb-2">taleTree</h1>
+          {/* Subtitle */}
+          <p className="text-white/90 text-sm md:text-base max-w-md">
+            A New Kind of Curriculum for a New Kind of World
+          </p>
+        </div>
+      </div>
+
       {/* SignupChatContainer with companion centered */}
       <div className="relative z-10 w-full h-full flex items-center justify-center">
         <SignupChatContainer

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -54,9 +54,9 @@ const HeroSection = () => {
         }}
       />
 
-      {/* SimplifiedChatContainer with companion positioned on ground */}
+      {/* SignupChatContainer with companion positioned on ground */}
       <div className="relative z-10 w-full h-full">
-        <SimplifiedChatContainer
+        <SignupChatContainer
           messages={chatMessages}
           className="w-full h-full"
           isAIThinking={false}

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -63,9 +63,9 @@ const HeroSection = () => {
         />
       </div>
 
-      {/* ChatInputBox for chatting */}
+      {/* SignupChatInput for chatting */}
       <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-2xl">
-        <ChatInputBox
+        <SignupChatInput
           onSendMessage={handleSendMessage}
           onAddAttachment={handleAddAttachment}
           placeholder="Ask me anything..."

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -25,7 +25,7 @@ const HeroSection = () => {
       />
 
       {/* SimplifiedChatContainer with companion positioned on ground */}
-      <div className="relative z-10 w-full h-full flex items-end justify-center pb-8">
+      <div className="relative z-10 w-full h-full overflow-visible">
         <SimplifiedChatContainer
           messages={sampleMessages}
           className="w-full h-full"

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,0 +1,30 @@
+import BunnyCharacter from "./BunnyCharacter";
+import SpeechBubble from "./SpeechBubble";
+import SearchSection from "./SearchSection";
+
+const HeroSection = () => {
+  return (
+    <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
+      {/* Background Landscape */}
+      <div className="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-green-400 via-yellow-300 to-transparent rounded-t-full transform scale-150 origin-bottom"></div>
+
+      {/* Mountains/Hills */}
+      <div className="absolute bottom-16 left-0 right-0 flex justify-center space-x-4">
+        <div className="w-32 h-24 bg-green-500 rounded-t-full"></div>
+        <div className="w-40 h-32 bg-green-600 rounded-t-full"></div>
+        <div className="w-28 h-20 bg-green-400 rounded-t-full"></div>
+      </div>
+
+      {/* Character - Green Bunny */}
+      <BunnyCharacter />
+
+      {/* Speech Bubble */}
+      <SpeechBubble message="It's time to start. Share the beautiful, magical stories and stories." />
+
+      {/* Search Input and Support Text */}
+      <SearchSection />
+    </div>
+  );
+};
+
+export default HeroSection;

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,8 +1,9 @@
+import { useState } from "react";
 import { SimplifiedChatContainer } from "@/components/SimplifiedChatContainer";
+import { ChatInputBox } from "@/components/ChatInputBox";
 
 const HeroSection = () => {
-  // Sample messages for the chat container
-  const sampleMessages = [
+  const [chatMessages, setChatMessages] = useState<any[]>([
     {
       id: "1",
       type: "text" as const,
@@ -10,7 +11,36 @@ const HeroSection = () => {
       content: "It's time to start. Share the beautiful, magical stories and stories.",
       timestamp: new Date(),
     }
-  ];
+  ]);
+
+  const handleSendMessage = (message: string) => {
+    // Add user message
+    const userMessage = {
+      id: Date.now().toString(),
+      type: "text" as const,
+      sender: "Kid" as const,
+      content: message,
+      timestamp: new Date(),
+    };
+    setChatMessages(prev => [...prev, userMessage]);
+
+    // Simulate AI response after a delay
+    setTimeout(() => {
+      const aiResponse = {
+        id: (Date.now() + 1).toString(),
+        type: "text" as const,
+        sender: "AI" as const,
+        content: `Thanks for sharing: "${message}". Let's explore this together!`,
+        timestamp: new Date(),
+      };
+      setChatMessages(prev => [...prev, aiResponse]);
+    }, 1500);
+  };
+
+  const handleAddAttachment = () => {
+    console.log("Add attachment clicked");
+    // You can implement file upload functionality here
+  };
 
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[80vh] px-4 overflow-hidden">
@@ -27,9 +57,18 @@ const HeroSection = () => {
       {/* SimplifiedChatContainer with companion positioned on ground */}
       <div className="relative z-10 w-full h-full">
         <SimplifiedChatContainer
-          messages={sampleMessages}
+          messages={chatMessages}
           className="w-full h-full"
           isAIThinking={false}
+        />
+      </div>
+
+      {/* ChatInputBox for chatting */}
+      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-2xl">
+        <ChatInputBox
+          onSendMessage={handleSendMessage}
+          onAddAttachment={handleAddAttachment}
+          placeholder="Ask me anything..."
         />
       </div>
     </div>

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -67,7 +67,6 @@ const HeroSection = () => {
       <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-2xl">
         <SignupChatInput
           onSendMessage={handleSendMessage}
-          onAddAttachment={handleAddAttachment}
           placeholder="Ask me anything..."
         />
       </div>

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -13,7 +13,7 @@ const HeroSection = () => {
   ];
 
   return (
-    <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
+    <div className="relative flex flex-col items-center justify-center min-h-[80vh] px-4 overflow-hidden">
       {/* Background Image */}
       <div
         className="absolute inset-0 w-full h-full bg-cover bg-center bg-no-repeat"
@@ -25,7 +25,7 @@ const HeroSection = () => {
       />
 
       {/* SimplifiedChatContainer with companion positioned on ground */}
-      <div className="relative z-10 w-full h-full overflow-visible">
+      <div className="relative z-10 w-full h-full">
         <SimplifiedChatContainer
           messages={sampleMessages}
           className="w-full h-full"

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -10,9 +10,10 @@ const HeroSection = () => {
       id: "1",
       type: "text" as const,
       sender: "AI" as const,
-      content: "It's time to start. Share the beautiful, magical stories and stories.",
+      content:
+        "It's time to start. Share the beautiful, magical stories and stories.",
       timestamp: new Date(),
-    }
+    },
   ]);
 
   const handleSendMessage = (message: string) => {
@@ -24,7 +25,7 @@ const HeroSection = () => {
       content: message,
       timestamp: new Date(),
     };
-    setChatMessages(prev => [...prev, userMessage]);
+    setChatMessages((prev) => [...prev, userMessage]);
 
     // Simulate AI response after a delay
     setTimeout(() => {
@@ -35,11 +36,9 @@ const HeroSection = () => {
         content: `Thanks for sharing: "${message}". Let's explore this together!`,
         timestamp: new Date(),
       };
-      setChatMessages(prev => [...prev, aiResponse]);
+      setChatMessages((prev) => [...prev, aiResponse]);
     }, 1500);
   };
-
-
 
   return (
     <div className="relative h-screen w-full overflow-hidden">
@@ -48,8 +47,8 @@ const HeroSection = () => {
         className="absolute inset-0 w-full h-full bg-cover bg-center bg-no-repeat z-0"
         style={{
           backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
-          backgroundPosition: 'center center',
-          backgroundSize: 'cover'
+          backgroundPosition: "center center",
+          backgroundSize: "cover",
         }}
       />
 
@@ -106,7 +105,12 @@ const HeroSection = () => {
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 14l-7 7m0 0l-7-7m7 7V3"
+            />
           </svg>
         </div>
       </div>

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { SignupChatContainer } from "./SignupChatContainer";
 import { SignupChatInput } from "./SignupChatInput";
 import { HeaderActions } from "./HeaderActions";
+import { SignupDualSidebar } from "./SignupDualSidebar";
 
 const HeroSection = () => {
   const [chatMessages, setChatMessages] = useState<any[]>([

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -66,11 +66,9 @@ const HeroSection = () => {
               className="w-full h-full object-contain"
             />
           </div>
-          {/* Title */}
-          <h1 className="text-white text-3xl md:text-4xl font-bold mb-2">taleTree</h1>
           {/* Subtitle */}
-          <p className="text-white/90 text-sm md:text-base max-w-md">
-            A New Kind of Curriculum for a New Kind of World
+          <p className="text-white/90 text-base md:text-lg max-w-md">
+            A New Kind of Curriculum
           </p>
         </div>
       </div>

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -37,10 +37,7 @@ const HeroSection = () => {
     }, 1500);
   };
 
-  const handleAddAttachment = () => {
-    console.log("Add attachment clicked");
-    // You can implement file upload functionality here
-  };
+
 
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[80vh] px-4 overflow-hidden">

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,6 +1,11 @@
+import { useState } from "react";
 import { SimplifiedChatContainer } from "@/components/SimplifiedChatContainer";
+import SearchChatMessage from "./SearchChatMessage";
 
 const HeroSection = () => {
+  const [searchResults, setSearchResults] = useState<string[]>([]);
+  const [hasSearched, setHasSearched] = useState(false);
+
   // Sample messages for the chat container
   const sampleMessages = [
     {
@@ -11,6 +16,18 @@ const HeroSection = () => {
       timestamp: new Date(),
     }
   ];
+
+  const handleSearch = (query: string) => {
+    console.log("Searching for:", query);
+    setHasSearched(true);
+    // Simulate search results
+    const mockResults = [
+      `Creative stories about ${query}`,
+      `Educational content for ${query}`,
+      `Interactive activities with ${query}`,
+    ];
+    setSearchResults(mockResults);
+  };
 
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
@@ -24,8 +41,8 @@ const HeroSection = () => {
         <div className="w-28 h-20 bg-green-400 rounded-t-full"></div>
       </div>
 
-      {/* SimplifiedChatContainer replacing bunny and search */}
-      <div className="relative z-10 w-full h-96">
+      {/* SimplifiedChatContainer with companion */}
+      <div className="relative z-10 w-full h-96 mb-8">
         <SimplifiedChatContainer
           messages={sampleMessages}
           className="w-full h-full"
@@ -33,8 +50,35 @@ const HeroSection = () => {
         />
       </div>
 
+      {/* Search using ChatMessage */}
+      <div className="relative z-10 w-full max-w-md mb-4">
+        <SearchChatMessage
+          onSearch={handleSearch}
+          placeholder="Search for stories, activities, or topics..."
+        />
+      </div>
+
+      {/* Search Results */}
+      {hasSearched && searchResults.length > 0 && (
+        <div className="relative z-10 w-full max-w-md mb-4">
+          <div className="bg-white/90 backdrop-blur-sm rounded-2xl p-4 shadow-lg border border-white/20">
+            <h4 className="text-sm font-bold text-purple-700 mb-2">Search Results:</h4>
+            <ul className="space-y-2">
+              {searchResults.map((result, index) => (
+                <li
+                  key={index}
+                  className="text-sm text-gray-700 p-2 bg-purple-50 rounded-lg hover:bg-purple-100 cursor-pointer transition-colors"
+                >
+                  {result}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
       {/* Support Text */}
-      <p className="relative z-10 text-white/80 text-sm mt-4">
+      <p className="relative z-10 text-white/80 text-sm">
         <span className="font-semibold">ADULTS</span> can get Support
       </p>
     </div>

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -53,6 +53,9 @@ const HeroSection = () => {
         }}
       />
 
+      {/* Dual Sidebar */}
+      <SignupDualSidebar />
+
       {/* Header Actions - Search and Login */}
       <HeaderActions />
 

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -47,8 +47,7 @@ const HeroSection = () => {
         style={{
           backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
           backgroundPosition: 'center center',
-          backgroundSize: 'cover',
-          backgroundAttachment: 'fixed'
+          backgroundSize: 'cover'
         }}
       />
 

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,8 +1,17 @@
-import BunnyCharacter from "./BunnyCharacter";
-import SpeechBubble from "./SpeechBubble";
-import SearchSection from "./SearchSection";
+import { SimplifiedChatContainer } from "@/components/SimplifiedChatContainer";
 
 const HeroSection = () => {
+  // Sample messages for the chat container
+  const sampleMessages = [
+    {
+      id: "1",
+      type: "text" as const,
+      sender: "AI" as const,
+      content: "It's time to start. Share the beautiful, magical stories and stories.",
+      timestamp: new Date(),
+    }
+  ];
+
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
       {/* Background Landscape */}
@@ -15,14 +24,19 @@ const HeroSection = () => {
         <div className="w-28 h-20 bg-green-400 rounded-t-full"></div>
       </div>
 
-      {/* Character - Green Bunny */}
-      <BunnyCharacter />
+      {/* SimplifiedChatContainer replacing bunny and search */}
+      <div className="relative z-10 w-full h-96">
+        <SimplifiedChatContainer
+          messages={sampleMessages}
+          className="w-full h-full"
+          isAIThinking={false}
+        />
+      </div>
 
-      {/* Speech Bubble */}
-      <SpeechBubble message="It's time to start. Share the beautiful, magical stories and stories." />
-
-      {/* Search Input and Support Text */}
-      <SearchSection />
+      {/* Support Text */}
+      <p className="relative z-10 text-white/80 text-sm mt-4">
+        <span className="font-semibold">ADULTS</span> can get Support
+      </p>
     </div>
   );
 };

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -31,15 +31,15 @@ const HeroSection = () => {
 
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
-      {/* Background Landscape */}
-      <div className="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-green-400 via-yellow-300 to-transparent rounded-t-full transform scale-150 origin-bottom"></div>
-
-      {/* Mountains/Hills */}
-      <div className="absolute bottom-16 left-0 right-0 flex justify-center space-x-4">
-        <div className="w-32 h-24 bg-green-500 rounded-t-full"></div>
-        <div className="w-40 h-32 bg-green-600 rounded-t-full"></div>
-        <div className="w-28 h-20 bg-green-400 rounded-t-full"></div>
-      </div>
+      {/* Background Image */}
+      <div
+        className="absolute inset-0 w-full h-full bg-cover bg-center bg-no-repeat"
+        style={{
+          backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
+          backgroundPosition: 'center bottom',
+          backgroundSize: 'cover'
+        }}
+      />
 
       {/* SimplifiedChatContainer with companion */}
       <div className="relative z-10 w-full h-96 mb-8">

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { SignupChatContainer } from "./SignupChatContainer";
 import { SignupChatInput } from "./SignupChatInput";
+import { HeaderActions } from "./HeaderActions";
 
 const HeroSection = () => {
   const [chatMessages, setChatMessages] = useState<any[]>([

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -52,6 +52,9 @@ const HeroSection = () => {
         }}
       />
 
+      {/* Header Actions - Search and Login */}
+      <HeaderActions />
+
       {/* SignupChatContainer with companion centered */}
       <div className="relative z-10 w-full h-full flex items-center justify-center">
         <SignupChatContainer

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -1,11 +1,6 @@
-import { useState } from "react";
 import { SimplifiedChatContainer } from "@/components/SimplifiedChatContainer";
-import SearchChatMessage from "./SearchChatMessage";
 
 const HeroSection = () => {
-  const [searchResults, setSearchResults] = useState<string[]>([]);
-  const [hasSearched, setHasSearched] = useState(false);
-
   // Sample messages for the chat container
   const sampleMessages = [
     {
@@ -16,18 +11,6 @@ const HeroSection = () => {
       timestamp: new Date(),
     }
   ];
-
-  const handleSearch = (query: string) => {
-    console.log("Searching for:", query);
-    setHasSearched(true);
-    // Simulate search results
-    const mockResults = [
-      `Creative stories about ${query}`,
-      `Educational content for ${query}`,
-      `Interactive activities with ${query}`,
-    ];
-    setSearchResults(mockResults);
-  };
 
   return (
     <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
@@ -41,46 +24,14 @@ const HeroSection = () => {
         }}
       />
 
-      {/* SimplifiedChatContainer with companion */}
-      <div className="relative z-10 w-full h-96 mb-8">
+      {/* SimplifiedChatContainer with companion positioned on ground */}
+      <div className="relative z-10 w-full h-full flex items-end justify-center pb-8">
         <SimplifiedChatContainer
           messages={sampleMessages}
           className="w-full h-full"
           isAIThinking={false}
         />
       </div>
-
-      {/* Search using ChatMessage */}
-      <div className="relative z-10 w-full max-w-md mb-4">
-        <SearchChatMessage
-          onSearch={handleSearch}
-          placeholder="Search for stories, activities, or topics..."
-        />
-      </div>
-
-      {/* Search Results */}
-      {hasSearched && searchResults.length > 0 && (
-        <div className="relative z-10 w-full max-w-md mb-4">
-          <div className="bg-white/90 backdrop-blur-sm rounded-2xl p-4 shadow-lg border border-white/20">
-            <h4 className="text-sm font-bold text-purple-700 mb-2">Search Results:</h4>
-            <ul className="space-y-2">
-              {searchResults.map((result, index) => (
-                <li
-                  key={index}
-                  className="text-sm text-gray-700 p-2 bg-purple-50 rounded-lg hover:bg-purple-100 cursor-pointer transition-colors"
-                >
-                  {result}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      )}
-
-      {/* Support Text */}
-      <p className="relative z-10 text-white/80 text-sm">
-        <span className="font-semibold">ADULTS</span> can get Support
-      </p>
     </div>
   );
 };

--- a/client/components/signup/HeroSection.tsx
+++ b/client/components/signup/HeroSection.tsx
@@ -40,19 +40,20 @@ const HeroSection = () => {
 
 
   return (
-    <div className="relative flex flex-col items-center justify-center min-h-[80vh] px-4 overflow-hidden">
+    <div className="relative h-screen w-full overflow-hidden">
       {/* Background Image */}
       <div
-        className="absolute inset-0 w-full h-full bg-cover bg-center bg-no-repeat"
+        className="absolute inset-0 w-full h-full bg-cover bg-center bg-no-repeat z-0"
         style={{
           backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
-          backgroundPosition: 'center bottom',
-          backgroundSize: 'cover'
+          backgroundPosition: 'center center',
+          backgroundSize: 'cover',
+          backgroundAttachment: 'fixed'
         }}
       />
 
-      {/* SignupChatContainer with companion positioned on ground */}
-      <div className="relative z-10 w-full h-full">
+      {/* SignupChatContainer with companion centered */}
+      <div className="relative z-10 w-full h-full flex items-center justify-center">
         <SignupChatContainer
           messages={chatMessages}
           className="w-full h-full"
@@ -61,11 +62,28 @@ const HeroSection = () => {
       </div>
 
       {/* SignupChatInput for chatting */}
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-20 w-full max-w-2xl">
+      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-30 w-full max-w-2xl px-4">
         <SignupChatInput
           onSendMessage={handleSendMessage}
           placeholder="Ask me anything..."
         />
+      </div>
+
+      {/* Scroll Indicator */}
+      <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-20 animate-bounce">
+        <div className="flex flex-col items-center text-white/80">
+          <div className="w-6 h-10 border-2 border-white/60 rounded-full flex justify-center">
+            <div className="w-1 h-3 bg-white/60 rounded-full mt-2 animate-pulse"></div>
+          </div>
+          <svg
+            className="w-4 h-4 mt-1"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+          </svg>
+        </div>
       </div>
     </div>
   );

--- a/client/components/signup/IntroducingSection.tsx
+++ b/client/components/signup/IntroducingSection.tsx
@@ -1,0 +1,36 @@
+const IntroducingSection = () => {
+  return (
+    <div className="px-8 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">
+          Introducing TaleTree
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Left - Character illustration */}
+        <div className="bg-gradient-to-br from-orange-400 to-red-500 rounded-xl p-6 h-64 relative overflow-hidden">
+          <div className="absolute bottom-4 left-4">
+            <div className="w-16 h-20 bg-orange-600 rounded-full relative">
+              {/* Simple character representation */}
+              <div className="absolute top-2 left-3 w-2 h-2 bg-white rounded-full"></div>
+              <div className="absolute top-2 right-3 w-2 h-2 bg-white rounded-full"></div>
+              <div className="absolute top-6 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-white rounded-full"></div>
+            </div>
+          </div>
+          <div className="absolute inset-0 bg-gradient-to-t from-green-400/20 to-transparent rounded-xl"></div>
+        </div>
+
+        {/* Right - Family photo placeholder */}
+        <div className="bg-gray-200 rounded-xl h-64 flex items-center justify-center">
+          <div className="text-center">
+            <div className="w-20 h-20 bg-gray-300 rounded-full mx-auto mb-4"></div>
+            <p className="text-gray-600 text-sm">Families that talk</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IntroducingSection;

--- a/client/components/signup/LatestNewsSection.tsx
+++ b/client/components/signup/LatestNewsSection.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+const LatestNewsSection = () => {
+  return (
+    <div className="px-8 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-xl font-semibold text-gray-900">Latest news</h3>
+        <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+          View all
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Card key={i} className="bg-gray-100 border-0">
+            <CardContent className="p-3">
+              <div className="w-full h-20 bg-gray-200 rounded mb-2"></div>
+              <p className="text-xs text-gray-600 mb-1">
+                News headline here
+              </p>
+              <p className="text-xs text-gray-500">Jan 24, 2024</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LatestNewsSection;

--- a/client/components/signup/ParentsSection.tsx
+++ b/client/components/signup/ParentsSection.tsx
@@ -1,0 +1,32 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+const ParentsSection = () => {
+  return (
+    <div className="px-8 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-xl font-semibold text-gray-900">Parents</h3>
+        <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+          View all
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="bg-gray-100 border-0">
+            <CardContent className="p-4">
+              <div className="w-full h-32 bg-gray-200 rounded mb-3"></div>
+              <p className="text-sm text-gray-700 mb-2">
+                Parent story title
+              </p>
+              <p className="text-xs text-gray-500">
+                Story description here
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ParentsSection;

--- a/client/components/signup/PlansStrip.tsx
+++ b/client/components/signup/PlansStrip.tsx
@@ -4,25 +4,22 @@ const PlansStrip = () => {
   return (
     <div className="relative z-10 bg-gray-50 border-t border-gray-200">
       {/* Plans Strip Container */}
-      <div className="py-4 px-6 mx-auto max-w-6xl">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-          {/* Left Side - Text Content */}
-          <div className="flex-1">
-            <h3 className="text-base font-medium text-gray-900 mb-1">
-              Creativity and kindness matter more than ever in the age of{' '}
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 ml-1">
-                AI
-              </span>
-            </h3>
-            <p className="text-sm text-gray-600">
-              TaleTree helps your child grow both — and get rewarded for it.
-            </p>
+      <div className="py-3 px-6 mx-auto max-w-6xl">
+        <div className="flex items-center justify-between">
+          {/* Left Side - New Badge + Text */}
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-green-100 text-green-800">
+              New
+            </span>
+            <span className="text-base font-medium text-gray-900">
+              TaleTree just got better!
+            </span>
           </div>
 
-          {/* Right Side - CTA Button */}
+          {/* Right Side - See Plans Button */}
           <div className="flex-shrink-0">
-            <button className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white font-medium py-2.5 px-6 rounded-full transition-all duration-200 shadow-sm hover:shadow-md text-sm">
-              Get Started
+            <button className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white font-medium py-2 px-6 rounded-full transition-all duration-200 shadow-sm hover:shadow-md text-sm">
+              See plans
             </button>
           </div>
         </div>

--- a/client/components/signup/PlansStrip.tsx
+++ b/client/components/signup/PlansStrip.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 const PlansStrip = () => {
   return (
-    <div className="relative z-10 bg-gray-50 border-t border-gray-200">
-      {/* Plans Strip Container */}
-      <div className="py-3 px-6 mx-auto max-w-6xl">
+    <div className="py-4 px-6 mx-auto max-w-6xl">
+      <div className="bg-gray-50 border border-gray-200 rounded-lg py-3 px-6">
         <div className="flex items-center justify-between">
           {/* Left Side - New Badge + Text */}
           <div className="flex items-center gap-3">

--- a/client/components/signup/PlansStrip.tsx
+++ b/client/components/signup/PlansStrip.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 
 const PlansStrip = () => {
   return (
-    <div className="relative z-10 bg-white border-t border-gray-100">
+    <div className="relative z-10 bg-gray-50 border-t border-gray-200">
       {/* Plans Strip Container */}
-      <div className="py-6 px-4 mx-auto max-w-7xl">
-        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+      <div className="py-4 px-6 mx-auto max-w-6xl">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           {/* Left Side - Text Content */}
-          <div className="flex-1 text-center sm:text-left">
-            <h3 className="text-lg font-semibold text-gray-900 mb-1">
-              Creativity and kindness matter more than ever in the age of AI
+          <div className="flex-1">
+            <h3 className="text-base font-medium text-gray-900 mb-1">
+              Creativity and kindness matter more than ever in the age of{' '}
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 ml-1">
+                AI
+              </span>
             </h3>
             <p className="text-sm text-gray-600">
               TaleTree helps your child grow both — and get rewarded for it.
@@ -18,8 +21,8 @@ const PlansStrip = () => {
 
           {/* Right Side - CTA Button */}
           <div className="flex-shrink-0">
-            <button className="bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white font-medium py-3 px-8 rounded-full transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105">
-              Explore Plans
+            <button className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white font-medium py-2.5 px-6 rounded-full transition-all duration-200 shadow-sm hover:shadow-md text-sm">
+              Get Started
             </button>
           </div>
         </div>

--- a/client/components/signup/PlansStrip.tsx
+++ b/client/components/signup/PlansStrip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 interface PlansStripProps {
   onShowPlans?: () => void;

--- a/client/components/signup/PlansStrip.tsx
+++ b/client/components/signup/PlansStrip.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-const PlansStrip = () => {
+interface PlansStripProps {
+  onShowPlans?: () => void;
+}
+
+const PlansStrip = ({ onShowPlans }: PlansStripProps) => {
   return (
     <div className="py-4 px-6 mx-auto max-w-6xl">
       <div className="bg-gray-50 border border-gray-200 rounded-lg py-3 px-6">

--- a/client/components/signup/PlansStrip.tsx
+++ b/client/components/signup/PlansStrip.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const PlansStrip = () => {
+  return (
+    <div className="relative z-10 bg-white border-t border-gray-100">
+      {/* Plans Strip Container */}
+      <div className="py-6 px-4 mx-auto max-w-7xl">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+          {/* Left Side - Text Content */}
+          <div className="flex-1 text-center sm:text-left">
+            <h3 className="text-lg font-semibold text-gray-900 mb-1">
+              Creativity and kindness matter more than ever in the age of AI
+            </h3>
+            <p className="text-sm text-gray-600">
+              TaleTree helps your child grow both — and get rewarded for it.
+            </p>
+          </div>
+
+          {/* Right Side - CTA Button */}
+          <div className="flex-shrink-0">
+            <button className="bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white font-medium py-3 px-8 rounded-full transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105">
+              Explore Plans
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlansStrip;

--- a/client/components/signup/PlansStrip.tsx
+++ b/client/components/signup/PlansStrip.tsx
@@ -21,7 +21,10 @@ const PlansStrip = ({ onShowPlans }: PlansStripProps) => {
 
           {/* Right Side - See Plans Button */}
           <div className="flex-shrink-0">
-            <button className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white font-medium py-2 px-6 rounded-full transition-all duration-200 shadow-sm hover:shadow-md text-sm">
+            <button
+              onClick={onShowPlans}
+              className="bg-gradient-to-r from-purple-600 to-purple-700 hover:from-purple-700 hover:to-purple-800 text-white font-medium py-2 px-6 rounded-full transition-all duration-200 shadow-sm hover:shadow-md text-sm"
+            >
               See plans
             </button>
           </div>

--- a/client/components/signup/SearchChatMessage.tsx
+++ b/client/components/signup/SearchChatMessage.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { ChatMessage } from "@/components/ChatMessage";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface SearchChatMessageProps {
+  onSearch?: (query: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+const SearchChatMessage = ({ 
+  onSearch = () => {}, 
+  placeholder = "Enter anything...",
+  className = ""
+}: SearchChatMessageProps) => {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const handleSearch = () => {
+    if (searchQuery.trim()) {
+      onSearch(searchQuery.trim());
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  const searchContent = (
+    <div className="space-y-3">
+      <div className="text-center mb-3">
+        <h3 className="text-base font-bold text-purple-700 mb-1">
+          🔍 What would you like to explore?
+        </h3>
+        <div className="h-0.5 w-12 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full mx-auto" />
+      </div>
+
+      <div className="relative">
+        <Input
+          type="text"
+          placeholder={placeholder}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyPress={handleKeyPress}
+          className="w-full h-12 pl-4 pr-16 rounded-full border-2 border-orange-300 bg-white text-black placeholder-gray-500 text-sm focus:border-orange-400 focus:ring-2 focus:ring-orange-200"
+        />
+        <Button 
+          onClick={handleSearch}
+          className="absolute right-2 top-2 h-8 w-8 bg-orange-400 hover:bg-orange-500 rounded-full p-0 transition-all duration-200 hover:scale-105"
+        >
+          <svg
+            className="w-4 h-4 text-white"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </Button>
+      </div>
+
+      <div className="flex items-center justify-center gap-2 text-xs text-purple-600">
+        <span className="font-semibold">💡</span>
+        <span>Try: "storytelling", "creativity", "learning"</span>
+      </div>
+    </div>
+  );
+
+  return (
+    <ChatMessage
+      role="AI"
+      content={searchContent}
+      timestamp={new Date()}
+      avatar="🔍"
+      className={className}
+    />
+  );
+};
+
+export default SearchChatMessage;

--- a/client/components/signup/SearchSection.tsx
+++ b/client/components/signup/SearchSection.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const SearchSection = () => {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  return (
+    <>
+      {/* Search Input Section */}
+      <div className="relative z-10 w-full max-w-md mb-4">
+        <div className="relative">
+          <Input
+            type="text"
+            placeholder="Enter anything..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full h-14 pl-4 pr-16 rounded-full border-2 border-orange-300 bg-white text-black placeholder-gray-500 text-lg"
+          />
+          <Button className="absolute right-2 top-2 h-10 w-10 bg-orange-400 hover:bg-orange-500 rounded-full p-0">
+            <svg
+              className="w-5 h-5 text-white"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          </Button>
+        </div>
+      </div>
+
+      {/* Support Text */}
+      <p className="relative z-10 text-white/80 text-sm">
+        <span className="font-semibold">ADULTS</span> can get Support
+      </p>
+    </>
+  );
+};
+
+export default SearchSection;

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-40 left-1/2 transform -translate-x-1/2">
+          <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-20">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-40 left-72">
+          <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-32">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,7 +66,7 @@ export function SignupChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-32 left-1/4 transform translate-x-16" key={message.id}>
+        <div className="absolute bottom-32 left-1/4 transform translate-x-16 z-20" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-32 left-1/4 transform translate-x-16 z-20">
+          <div className="absolute bottom-32 left-1/4 transform translate-x-24 z-10">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-32">
+          <div className="absolute bottom-40 left-1/2 transform -translate-x-1/2">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -94,8 +94,8 @@ export function SignupChatContainer({
 
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
-      {/* Fixed Companion Character above chat input and on ground */}
-      <div className="absolute bottom-20 left-1/2 transform -translate-x-1/2 -translate-x-32 z-10 hover:scale-105 transition-transform duration-300">
+      {/* Fixed Companion Character on left side above chat input and on ground */}
+      <div className="absolute bottom-24 left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -63,15 +63,15 @@ export function SignupChatContainer({
   const { latestAI, latestKid } = getLatestMessages();
 
   const renderMessage = (message: ChatMessage) => {
-    // AI text messages - positioned right next to companion mouth, responsive
+    // AI text messages - positioned at red square location (top-center)
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-24 sm:bottom-32 md:bottom-36 left-1/4 transform translate-x-12 sm:translate-x-16 md:translate-x-20 lg:translate-x-24 z-10" key={message.id}>
+        <div className="absolute top-20 sm:top-24 md:top-28 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
           <div className="max-w-xs sm:max-w-sm md:max-w-md">
             <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-xs sm:text-sm leading-relaxed">{message.content}</p>
-              {/* Speech bubble tail pointing to companion */}
-              <div className="absolute bottom-0 left-2 sm:left-4 w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
+              {/* Speech bubble tail pointing down to companion */}
+              <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-full w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500"></div>
             </div>
           </div>
         </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute top-20 sm:top-24 md:top-28 left-1/2 transform -translate-x-1/2 z-10">
+          <div className="absolute bottom-32 sm:bottom-40 md:bottom-48 lg:bottom-56 left-1/2 transform -translate-x-1/2 z-10">
             <div className="max-w-xs sm:max-w-sm md:max-w-md">
               <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-xs sm:text-sm leading-relaxed">
@@ -167,8 +167,8 @@ export function SignupChatContainer({
                   <br />
                   Let's create something amazing together!
                 </p>
-                {/* Speech bubble tail pointing down to companion */}
-                <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-full w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500"></div>
+                {/* Speech bubble tail pointing to companion */}
+                <div className="absolute bottom-0 left-4 sm:left-6 w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
               </div>
             </div>
           </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 ml-48 -mt-16">
+          <div className="absolute bottom-40 left-72">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -94,8 +94,8 @@ export function SignupChatContainer({
 
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
-      {/* Fixed Companion Character on left side and ground */}
-      <div className="absolute bottom-0 left-20 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      {/* Fixed Companion Character above chat input and on ground */}
+      <div className="absolute bottom-20 left-1/2 transform -translate-x-1/2 -translate-x-32 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -94,8 +94,8 @@ export function SignupChatContainer({
 
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
-      {/* Fixed Companion Character grounded on landscape */}
-      <div className="absolute bottom-[-150px] left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      {/* Fixed Companion Character centered in viewport */}
+      <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,10 +156,10 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-32 left-1/4 transform translate-x-24 z-10">
-            <div className="max-w-sm">
-              <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
-                <p className="text-sm leading-relaxed">
+          <div className="absolute bottom-24 sm:bottom-32 md:bottom-36 left-1/4 transform translate-x-12 sm:translate-x-16 md:translate-x-20 lg:translate-x-24 z-10">
+            <div className="max-w-xs sm:max-w-sm md:max-w-md">
+              <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
+                <p className="text-xs sm:text-sm leading-relaxed">
                   Hello, brave explorer! 🌟
                   <br />
                   Welcome to TaleTree! Share your magical stories and ideas with me.
@@ -168,7 +168,7 @@ export function SignupChatContainer({
                   Let's create something amazing together!
                 </p>
                 {/* Speech bubble tail pointing to companion */}
-                <div className="absolute bottom-0 left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
+                <div className="absolute bottom-0 left-2 sm:left-4 w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
               </div>
             </div>
           </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,10 +66,15 @@ export function SignupChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-3/5 sm:left-2/3 md:left-3/5 lg:left-3/5 transform -translate-x-1/2 z-10" key={message.id}>
+        <div
+          className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-3/5 sm:left-2/3 md:left-3/5 lg:left-3/5 transform -translate-x-1/2 z-10"
+          key={message.id}
+        >
           <div className="max-w-xs sm:max-w-sm md:max-w-md">
             <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
-              <p className="text-xs sm:text-sm leading-relaxed">{message.content}</p>
+              <p className="text-xs sm:text-sm leading-relaxed">
+                {message.content}
+              </p>
               {/* Speech bubble tail pointing to companion */}
               <div className="absolute bottom-0 left-4 sm:left-6 w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
             </div>
@@ -162,7 +167,8 @@ export function SignupChatContainer({
                 <p className="text-xs sm:text-sm leading-relaxed">
                   Hello, brave explorer! 🌟
                   <br />
-                  Welcome to TaleTree! Share your magical stories and ideas with me.
+                  Welcome to TaleTree! Share your magical stories and ideas with
+                  me.
                   <br />
                   <br />
                   Let's create something amazing together!

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,7 +66,7 @@ export function SignupChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-32 sm:bottom-40 md:bottom-48 lg:bottom-56 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
+        <div className="absolute bottom-40 sm:bottom-48 md:bottom-56 lg:bottom-64 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
           <div className="max-w-xs sm:max-w-sm md:max-w-md">
             <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-xs sm:text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-32 left-1/4 transform translate-x-16">
+          <div className="absolute bottom-32 left-1/4 transform translate-x-16 z-20">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -94,8 +94,8 @@ export function SignupChatContainer({
 
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
-      {/* Fixed Companion Character centered in viewport */}
-      <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 hover:scale-105 transition-transform duration-300">
+      {/* Fixed Companion Character on left side and ground */}
+      <div className="absolute bottom-0 left-20 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
         <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,11 +66,11 @@ export function SignupChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-20" key={message.id}>
+        <div className="absolute bottom-32 left-1/4 transform translate-x-16" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>
-              {/* Speech bubble tail */}
+              {/* Speech bubble tail pointing to companion */}
               <div className="absolute bottom-0 left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
             </div>
           </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,7 +66,7 @@ export function SignupChatContainer({
     // AI text messages - positioned near companion
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-40 left-72" key={message.id}>
+        <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-32" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -63,10 +63,10 @@ export function SignupChatContainer({
   const { latestAI, latestKid } = getLatestMessages();
 
   const renderMessage = (message: ChatMessage) => {
-    // AI text messages - positioned at companion mouth level
+    // AI text messages - positioned to the right of companion mouth
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-32 left-1/4 transform translate-x-16 z-20" key={message.id}>
+        <div className="absolute bottom-32 left-1/4 transform translate-x-24 z-10" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-20">
+          <div className="absolute bottom-32 left-1/4 transform translate-x-16">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">
@@ -167,7 +167,7 @@ export function SignupChatContainer({
                   <br />
                   Let's create something amazing together!
                 </p>
-                {/* Speech bubble tail */}
+                {/* Speech bubble tail pointing to companion */}
                 <div className="absolute bottom-0 left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
               </div>
             </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-32 sm:bottom-40 md:bottom-48 lg:bottom-56 left-1/2 transform -translate-x-1/2 z-10">
+          <div className="absolute bottom-40 sm:bottom-48 md:bottom-56 lg:bottom-64 left-1/2 transform -translate-x-1/2 z-10">
             <div className="max-w-xs sm:max-w-sm md:max-w-md">
               <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-xs sm:text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -63,15 +63,15 @@ export function SignupChatContainer({
   const { latestAI, latestKid } = getLatestMessages();
 
   const renderMessage = (message: ChatMessage) => {
-    // AI text messages - positioned to the right of companion mouth
+    // AI text messages - positioned right next to companion mouth, responsive
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-32 left-1/4 transform translate-x-24 z-10" key={message.id}>
-          <div className="max-w-sm">
-            <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
-              <p className="text-sm leading-relaxed">{message.content}</p>
+        <div className="absolute bottom-24 sm:bottom-32 md:bottom-36 left-1/4 transform translate-x-12 sm:translate-x-16 md:translate-x-20 lg:translate-x-24 z-10" key={message.id}>
+          <div className="max-w-xs sm:max-w-sm md:max-w-md">
+            <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
+              <p className="text-xs sm:text-sm leading-relaxed">{message.content}</p>
               {/* Speech bubble tail pointing to companion */}
-              <div className="absolute bottom-0 left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
+              <div className="absolute bottom-0 left-2 sm:left-4 w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
             </div>
           </div>
         </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -1,0 +1,181 @@
+import { useState, useEffect } from "react";
+import Lottie from "lottie-react";
+
+interface ChatMessage {
+  id: string;
+  type: "text" | "system";
+  sender: "AI" | "Kid";
+  content?: string;
+  timestamp: Date;
+}
+
+interface SignupChatContainerProps {
+  messages: ChatMessage[];
+  className?: string;
+  isAIThinking?: boolean;
+}
+
+export function SignupChatContainer({
+  messages,
+  className = "",
+  isAIThinking = false,
+}: SignupChatContainerProps) {
+  // State for Lottie animation data
+  const [animationData, setAnimationData] = useState(null);
+
+  // Load Lottie animation data
+  useEffect(() => {
+    const loadAnimation = async () => {
+      try {
+        const response = await fetch(
+          "https://cdn.builder.io/o/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2Faf1bb45b193d45099ddf3851679da168?alt=media&token=e1de5c73-b4dc-4ba8-add2-191d7b69446e&apiKey=da24af11bdbb4585b8e6eb6406b2daf9",
+        );
+        const data = await response.json();
+        setAnimationData(data);
+      } catch (error) {
+        console.error("Failed to load Lottie animation:", error);
+      }
+    };
+
+    loadAnimation();
+  }, []);
+
+  // Get the latest AI and Kid messages separately
+  const getLatestMessages = () => {
+    let latestAI = null;
+    let latestKid = null;
+
+    // Find the most recent AI and Kid messages
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.sender === "AI" && !latestAI) {
+        latestAI = message;
+      }
+      if (message.sender === "Kid" && !latestKid) {
+        latestKid = message;
+      }
+      if (latestAI && latestKid) break;
+    }
+
+    return { latestAI, latestKid };
+  };
+
+  const { latestAI, latestKid } = getLatestMessages();
+
+  const renderMessage = (message: ChatMessage) => {
+    // AI text messages - positioned at companion mouth level
+    if (message.sender === "AI") {
+      return (
+        <div className="absolute bottom-[-20px] left-1/2" key={message.id}>
+          <div className="max-w-sm">
+            <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
+              <p className="text-sm leading-relaxed">{message.content}</p>
+              {/* Speech bubble tail */}
+              <div className="absolute bottom-0 left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Kid messages - positioned below AI message on the right
+    return (
+      <div className="absolute bottom-28 right-8" key={message.id}>
+        <div className="max-w-xs">
+          <div className="bg-green-500 text-white p-3 rounded-2xl rounded-br-sm shadow-lg relative">
+            <p className="text-sm leading-relaxed">{message.content}</p>
+            {/* Speech bubble tail */}
+            <div className="absolute bottom-0 right-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-green-500 transform translate-y-full"></div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className={`flex flex-col h-full relative ${className}`}>
+      {/* Fixed Companion Character grounded on landscape */}
+      <div className="absolute bottom-[-150px] left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+        <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
+          {/* Magical glow effect */}
+          <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>
+          {animationData ? (
+            <Lottie
+              animationData={animationData}
+              loop={true}
+              autoplay={true}
+              className="w-full h-full object-contain drop-shadow-2xl relative z-10"
+              style={{
+                width: "100%",
+                height: "100%",
+                filter: "drop-shadow(0 0 20px rgba(255, 255, 255, 0.3))",
+              }}
+            />
+          ) : (
+            // Fallback image while loading
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F39f348f7483547d18b45c8bfcdc8ad42?format=webp&width=800"
+              alt="AI Companion"
+              className="w-full h-full object-contain animate-gentle-float drop-shadow-2xl relative z-10"
+              style={{
+                filter: "drop-shadow(0 0 20px rgba(255, 255, 255, 0.3))",
+              }}
+            />
+          )}
+        </div>
+        {isAIThinking && (
+          <div className="absolute -top-12 left-1/2 transform -translate-x-1/2 animate-bounce">
+            <div className="bg-blue-500 text-white px-4 py-2 rounded-full text-sm shadow-lg">
+              <div className="flex items-center gap-2">
+                <div className="w-2 h-2 bg-white rounded-full animate-pulse"></div>
+                <div
+                  className="w-2 h-2 bg-white rounded-full animate-pulse"
+                  style={{ animationDelay: "0.2s" }}
+                ></div>
+                <div
+                  className="w-2 h-2 bg-white rounded-full animate-pulse"
+                  style={{ animationDelay: "0.4s" }}
+                ></div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Messages Container - positioned absolutely for precise placement */}
+      <div className="relative w-full h-full">
+        {/* Latest AI Message - above companion */}
+        {latestAI && (
+          <div className="animate-slide-in">{renderMessage(latestAI)}</div>
+        )}
+
+        {/* Latest Kid Message - on the right */}
+        {latestKid && (
+          <div className="animate-slide-in">{renderMessage(latestKid)}</div>
+        )}
+
+        {/* Default state when no messages */}
+        {!latestAI && !latestKid && (
+          <div className="absolute bottom-[-20px] left-1/2">
+            <div className="max-w-sm">
+              <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
+                <p className="text-sm leading-relaxed">
+                  Hello, brave explorer! 🌟
+                  <br />
+                  Welcome to TaleTree! Share your magical stories and ideas with me.
+                  <br />
+                  <br />
+                  Let's create something amazing together!
+                </p>
+                {/* Speech bubble tail */}
+                <div className="absolute bottom-0 left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export type { ChatMessage };

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -63,10 +63,10 @@ export function SignupChatContainer({
   const { latestAI, latestKid } = getLatestMessages();
 
   const renderMessage = (message: ChatMessage) => {
-    // AI text messages - positioned at companion mouth level
+    // AI text messages - positioned near companion
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-[-20px] left-1/2" key={message.id}>
+        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 ml-48 -mt-16" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -63,15 +63,15 @@ export function SignupChatContainer({
   const { latestAI, latestKid } = getLatestMessages();
 
   const renderMessage = (message: ChatMessage) => {
-    // AI text messages - positioned at red square location (top-center)
+    // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute top-20 sm:top-24 md:top-28 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
+        <div className="absolute bottom-32 sm:bottom-40 md:bottom-48 lg:bottom-56 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
           <div className="max-w-xs sm:max-w-sm md:max-w-md">
             <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-xs sm:text-sm leading-relaxed">{message.content}</p>
-              {/* Speech bubble tail pointing down to companion */}
-              <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-full w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500"></div>
+              {/* Speech bubble tail pointing to companion */}
+              <div className="absolute bottom-0 left-4 sm:left-6 w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
             </div>
           </div>
         </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,7 +66,7 @@ export function SignupChatContainer({
     // AI text messages - positioned near companion
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-32" key={message.id}>
+        <div className="absolute bottom-40 left-1/2 transform -translate-x-1/2" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,7 +66,7 @@ export function SignupChatContainer({
     // AI text messages - positioned near companion
     if (message.sender === "AI") {
       return (
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 ml-48 -mt-16" key={message.id}>
+        <div className="absolute bottom-40 left-72" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-[-20px] left-1/2">
+          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 ml-48 -mt-16">
             <div className="max-w-sm">
               <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,7 +66,7 @@ export function SignupChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-40 sm:bottom-48 md:bottom-56 lg:bottom-64 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
+        <div className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
           <div className="max-w-xs sm:max-w-sm md:max-w-md">
             <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-xs sm:text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -66,7 +66,7 @@ export function SignupChatContainer({
     // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-1/2 transform -translate-x-1/2 z-10" key={message.id}>
+        <div className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-3/5 sm:left-2/3 md:left-3/5 lg:left-3/5 transform -translate-x-1/2 z-10" key={message.id}>
           <div className="max-w-xs sm:max-w-sm md:max-w-md">
             <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-xs sm:text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-24 sm:bottom-32 md:bottom-36 left-1/4 transform translate-x-12 sm:translate-x-16 md:translate-x-20 lg:translate-x-24 z-10">
+          <div className="absolute top-20 sm:top-24 md:top-28 left-1/2 transform -translate-x-1/2 z-10">
             <div className="max-w-xs sm:max-w-sm md:max-w-md">
               <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-xs sm:text-sm leading-relaxed">
@@ -167,8 +167,8 @@ export function SignupChatContainer({
                   <br />
                   Let's create something amazing together!
                 </p>
-                {/* Speech bubble tail pointing to companion */}
-                <div className="absolute bottom-0 left-2 sm:left-4 w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500 transform translate-y-full"></div>
+                {/* Speech bubble tail pointing down to companion */}
+                <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-full w-0 h-0 border-l-4 sm:border-l-8 border-r-4 sm:border-r-8 border-t-4 sm:border-t-8 border-l-transparent border-r-transparent border-t-blue-500"></div>
               </div>
             </div>
           </div>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-1/2 transform -translate-x-1/2 z-10">
+          <div className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-3/5 sm:left-2/3 md:left-3/5 lg:left-3/5 transform -translate-x-1/2 z-10">
             <div className="max-w-xs sm:max-w-sm md:max-w-md">
               <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-xs sm:text-sm leading-relaxed">

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -63,10 +63,10 @@ export function SignupChatContainer({
   const { latestAI, latestKid } = getLatestMessages();
 
   const renderMessage = (message: ChatMessage) => {
-    // AI text messages - positioned near companion
+    // AI text messages - positioned at companion mouth level
     if (message.sender === "AI") {
       return (
-        <div className="absolute bottom-40 left-1/2 transform -translate-x-1/2" key={message.id}>
+        <div className="absolute bottom-32 left-1/2 transform -translate-x-1/2 translate-x-20" key={message.id}>
           <div className="max-w-sm">
             <div className="bg-blue-500 text-white p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
               <p className="text-sm leading-relaxed">{message.content}</p>

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -94,9 +94,9 @@ export function SignupChatContainer({
 
   return (
     <div className={`flex flex-col h-full relative ${className}`}>
-      {/* Fixed Companion Character on left side above chat input and on ground */}
-      <div className="absolute bottom-24 left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
-        <div className="w-64 h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
+      {/* Fixed Companion Character on left side above chat input and on ground - responsive */}
+      <div className="absolute bottom-16 sm:bottom-20 md:bottom-24 left-1/4 transform -translate-x-1/2 z-10 hover:scale-105 transition-transform duration-300">
+        <div className="w-48 h-48 sm:w-64 sm:h-64 md:w-80 md:h-80 lg:w-96 lg:h-96 relative">
           {/* Magical glow effect */}
           <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-400/20 to-pink-400/20 blur-xl animate-pulse"></div>
           {animationData ? (

--- a/client/components/signup/SignupChatContainer.tsx
+++ b/client/components/signup/SignupChatContainer.tsx
@@ -156,7 +156,7 @@ export function SignupChatContainer({
 
         {/* Default state when no messages */}
         {!latestAI && !latestKid && (
-          <div className="absolute bottom-40 sm:bottom-48 md:bottom-56 lg:bottom-64 left-1/2 transform -translate-x-1/2 z-10">
+          <div className="absolute bottom-56 sm:bottom-72 md:bottom-80 lg:bottom-96 left-1/2 transform -translate-x-1/2 z-10">
             <div className="max-w-xs sm:max-w-sm md:max-w-md">
               <div className="bg-blue-500 text-white p-2 sm:p-3 rounded-2xl rounded-bl-sm shadow-lg relative">
                 <p className="text-xs sm:text-sm leading-relaxed">

--- a/client/components/signup/SignupChatInput.tsx
+++ b/client/components/signup/SignupChatInput.tsx
@@ -30,11 +30,7 @@ export function SignupChatInput({
     }
   };
 
-  const handleAddClick = () => {
-    if (onAddAttachment) {
-      onAddAttachment();
-    }
-  };
+
 
   return (
     <div className="w-full max-w-2xl mx-auto px-4">

--- a/client/components/signup/SignupChatInput.tsx
+++ b/client/components/signup/SignupChatInput.tsx
@@ -46,14 +46,7 @@ export function SignupChatInput({
           boxShadow: "0px 6px 24px rgba(0, 0, 0, 0.12)",
         }}
       >
-        {/* Add/Plus Button */}
-        <Button
-          onClick={handleAddClick}
-          disabled={disabled}
-          className="w-9 h-9 rounded-full bg-orange-100 hover:bg-orange-200 p-0 border-0 flex-shrink-0 transition-all duration-200"
-        >
-          <Plus className="w-4 h-4 text-orange-600" />
-        </Button>
+
 
         {/* Text Input */}
         <div className="flex-1 relative">

--- a/client/components/signup/SignupChatInput.tsx
+++ b/client/components/signup/SignupChatInput.tsx
@@ -1,0 +1,98 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Plus, ArrowUp, Mic } from "lucide-react";
+import { useState } from "react";
+
+interface SignupChatInputProps {
+  onSendMessage?: (message: string) => void;
+  onAddAttachment?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function SignupChatInput({
+  onSendMessage,
+  onAddAttachment,
+  placeholder = "Ask me anything...",
+  disabled = false,
+}: SignupChatInputProps) {
+  const [message, setMessage] = useState("");
+
+  const handleSend = () => {
+    if (message.trim() && onSendMessage) {
+      onSendMessage(message.trim());
+      setMessage("");
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleAddClick = () => {
+    if (onAddAttachment) {
+      onAddAttachment();
+    }
+  };
+
+  return (
+    <div className="w-full max-w-2xl mx-auto px-4">
+      <div
+        className="flex items-center gap-2 bg-white rounded-full shadow-xl border border-gray-200 px-3 py-2"
+        style={{
+          boxShadow: "0px 6px 24px rgba(0, 0, 0, 0.12)",
+        }}
+      >
+        {/* Add/Plus Button */}
+        <Button
+          onClick={handleAddClick}
+          disabled={disabled}
+          className="w-9 h-9 rounded-full bg-orange-100 hover:bg-orange-200 p-0 border-0 flex-shrink-0 transition-all duration-200"
+        >
+          <Plus className="w-4 h-4 text-orange-600" />
+        </Button>
+
+        {/* Text Input */}
+        <div className="flex-1 relative">
+          <Input
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder={placeholder}
+            disabled={disabled}
+            className="border-0 bg-transparent focus:ring-0 focus:outline-none px-3 py-2 text-gray-800 placeholder:text-gray-500 h-auto text-sm"
+            style={{
+              boxShadow: "none",
+            }}
+          />
+        </div>
+
+        {/* Microphone Button */}
+        <Button
+          disabled={disabled}
+          className="w-9 h-9 rounded-full bg-gray-100 hover:bg-gray-200 p-0 border-0 flex-shrink-0 transition-all duration-200"
+        >
+          <Mic className="w-4 h-4 text-gray-600" />
+        </Button>
+
+        {/* Send Button */}
+        <Button
+          onClick={handleSend}
+          disabled={disabled || !message.trim()}
+          className="w-9 h-9 rounded-full p-0 border-0 flex-shrink-0 transition-all duration-200 hover:scale-110"
+          style={{
+            background: message.trim() 
+              ? "linear-gradient(135deg, #4FC3F7 0%, #29B6F6 100%)" 
+              : "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
+            opacity: !message.trim() ? 0.6 : 1,
+          }}
+        >
+          <ArrowUp className="w-4 h-4 text-white" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/components/signup/SignupChatInput.tsx
+++ b/client/components/signup/SignupChatInput.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Plus, ArrowUp, Mic } from "lucide-react";
+import { ArrowUp, Mic } from "lucide-react";
 import { useState } from "react";
 
 interface SignupChatInputProps {

--- a/client/components/signup/SignupChatInput.tsx
+++ b/client/components/signup/SignupChatInput.tsx
@@ -30,8 +30,6 @@ export function SignupChatInput({
     }
   };
 
-
-
   return (
     <div className="w-full max-w-4xl mx-auto px-4">
       <div
@@ -40,8 +38,6 @@ export function SignupChatInput({
           boxShadow: "0px 6px 24px rgba(0, 0, 0, 0.12)",
         }}
       >
-
-
         {/* Text Input */}
         <div className="flex-1 relative">
           <Input
@@ -71,8 +67,8 @@ export function SignupChatInput({
           disabled={disabled || !message.trim()}
           className="w-9 h-9 rounded-full p-0 border-0 flex-shrink-0 transition-all duration-200 hover:scale-110"
           style={{
-            background: message.trim() 
-              ? "linear-gradient(135deg, #4FC3F7 0%, #29B6F6 100%)" 
+            background: message.trim()
+              ? "linear-gradient(135deg, #4FC3F7 0%, #29B6F6 100%)"
               : "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
             opacity: !message.trim() ? 0.6 : 1,
           }}

--- a/client/components/signup/SignupChatInput.tsx
+++ b/client/components/signup/SignupChatInput.tsx
@@ -5,14 +5,12 @@ import { useState } from "react";
 
 interface SignupChatInputProps {
   onSendMessage?: (message: string) => void;
-  onAddAttachment?: () => void;
   placeholder?: string;
   disabled?: boolean;
 }
 
 export function SignupChatInput({
   onSendMessage,
-  onAddAttachment,
   placeholder = "Ask me anything...",
   disabled = false,
 }: SignupChatInputProps) {

--- a/client/components/signup/SignupChatInput.tsx
+++ b/client/components/signup/SignupChatInput.tsx
@@ -33,7 +33,7 @@ export function SignupChatInput({
 
 
   return (
-    <div className="w-full max-w-2xl mx-auto px-4">
+    <div className="w-full max-w-4xl mx-auto px-4">
       <div
         className="flex items-center gap-2 bg-white rounded-full shadow-xl border border-gray-200 px-3 py-2"
         style={{

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { TaleTreeWheelModal } from "./TaleTreeWheelModal";
+import { CompanionSelectionModal } from "./CompanionSelectionModal";
 
 interface MenuItem {
   src: string;

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -19,7 +19,7 @@ interface SignupDualSidebarProps {
 export function SignupDualSidebar({
   topMenuItems = [
     {
-      src: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F616e1bb5209e4aa1a9344292cfe45f71?format=webp&width=800",
+      src: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fcb34a17284254803ab9d0f3977ab5c38?format=webp&width=800",
       alt: "Menu",
       delay: 100
     }

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -224,6 +224,16 @@ export function SignupDualSidebar({
         isOpen={isWheelModalOpen}
         onClose={() => setIsWheelModalOpen(false)}
       />
+
+      {/* Companion Selection Modal */}
+      <CompanionSelectionModal
+        isOpen={isCompanionModalOpen}
+        onClose={() => setIsCompanionModalOpen(false)}
+        onSelectCompanion={(companionId) => {
+          console.log("Selected companion:", companionId);
+          // Here you can add logic to update the selected companion
+        }}
+      />
     </div>
   );
 }

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -38,6 +38,7 @@ export function SignupDualSidebar({
   const [showTopWaveEffect, setShowTopWaveEffect] = useState(true);
   const [showBottomWaveEffect, setShowBottomWaveEffect] = useState(true);
   const [isWheelModalOpen, setIsWheelModalOpen] = useState(false);
+  const [isCompanionModalOpen, setIsCompanionModalOpen] = useState(false);
 
   const toggleTopSidebar = () => {
     setTopSidebarCollapsed(!topSidebarCollapsed);

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -103,7 +103,7 @@ export function SignupDualSidebar({
         <div className="relative">
           <div
             className={`bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl transition-all duration-500 ease-in-out relative ${
-              topSidebarCollapsed ? "w-12" : "w-20"
+              topSidebarCollapsed ? "w-8" : "w-20"
             }`}
             style={{
               borderRadius: "0 15px 15px 0",

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -274,8 +274,8 @@ export function SignupDualSidebar({
         isOpen={isCompanionModalOpen}
         onClose={() => setIsCompanionModalOpen(false)}
         onSelectCompanion={(companionId) => {
+          handleCompanionSelect(companionId);
           console.log("Selected companion:", companionId);
-          // Here you can add logic to update the selected companion
         }}
       />
     </div>

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -215,6 +215,12 @@ export function SignupDualSidebar({
           </Button>
         </div>
       </div>
+
+      {/* TaleTree Wheel Modal */}
+      <TaleTreeWheelModal
+        isOpen={isWheelModalOpen}
+        onClose={() => setIsWheelModalOpen(false)}
+      />
     </div>
   );
 }

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -21,8 +21,8 @@ export function SignupDualSidebar({
     {
       src: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fcb34a17284254803ab9d0f3977ab5c38?format=webp&width=800",
       alt: "Menu",
-      delay: 100
-    }
+      delay: 100,
+    },
   ],
   bottomMenuItems,
   onMenuItemClick,
@@ -36,7 +36,8 @@ export function SignupDualSidebar({
   const [selectedCompanion, setSelectedCompanion] = useState({
     id: "letsgo",
     name: "Letsgo",
-    image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800"
+    image:
+      "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
   });
 
   const toggleTopSidebar = () => {
@@ -51,37 +52,44 @@ export function SignupDualSidebar({
   const companionMapping = {
     letsgo: {
       name: "Letsgo",
-      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800"
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
     },
     rushmore: {
       name: "Rushmore",
-      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800"
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800",
     },
     uni: {
       name: "Uni",
-      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800"
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800",
     },
     cody: {
       name: "Cody",
-      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800"
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800",
     },
     doma: {
       name: "Doma",
-      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800"
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800",
     },
     rooty: {
       name: "Rooty",
-      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800"
-    }
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800",
+    },
   };
 
   const handleCompanionSelect = (companionId: string) => {
-    const companion = companionMapping[companionId as keyof typeof companionMapping];
+    const companion =
+      companionMapping[companionId as keyof typeof companionMapping];
     if (companion) {
       setSelectedCompanion({
         id: companionId,
         name: companion.name,
-        image: companion.image
+        image: companion.image,
       });
     }
   };
@@ -91,8 +99,8 @@ export function SignupDualSidebar({
     {
       src: selectedCompanion.image,
       alt: selectedCompanion.name,
-      delay: 100
-    }
+      delay: 100,
+    },
   ];
 
   return (
@@ -128,9 +136,7 @@ export function SignupDualSidebar({
                         animation: showTopWaveEffect
                           ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
                           : "none",
-                        transform: showTopWaveEffect
-                          ? "scale(1)"
-                          : "scale(0)",
+                        transform: showTopWaveEffect ? "scale(1)" : "scale(0)",
                       }}
                     >
                       <div
@@ -222,7 +228,10 @@ export function SignupDualSidebar({
                       <div
                         className="w-12 h-12 rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 hover:scale-110 hover:shadow-lg hover:ring-2 hover:ring-white/30 bg-white/5 hover:bg-white/15 backdrop-blur-sm border border-white/10 hover:border-white/30"
                         onClick={() => {
-                          if (item.alt === selectedCompanion.name || item.alt === "Selected Companion") {
+                          if (
+                            item.alt === selectedCompanion.name ||
+                            item.alt === "Selected Companion"
+                          ) {
                             setIsCompanionModalOpen(true);
                           } else {
                             onMenuItemClick?.(item.alt, index);

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -100,23 +100,24 @@ export function SignupDualSidebar({
       {/* Container with zero margin, aligned to left edge */}
       <div className="flex flex-col gap-3 py-4 h-screen max-h-screen overflow-hidden mt-20">
         {/* Top Sidebar Section */}
-        <div className="flex items-center relative">
-          {/* Top Section Content */}
+        <div className="relative">
           <div
-            className={`transition-all duration-500 ease-in-out overflow-hidden ${
-              topSidebarCollapsed ? "w-0 opacity-0" : "w-20 opacity-100"
+            className={`bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl transition-all duration-500 ease-in-out relative ${
+              topSidebarCollapsed ? "w-12" : "w-20"
             }`}
+            style={{
+              borderRadius: "0 15px 15px 0",
+              boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
+              height: "auto",
+              maxHeight: "calc(60vh)",
+            }}
           >
+            {/* Menu Items */}
             <div
-              className="bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl flex flex-col p-4"
-              style={{
-                borderRadius: "0 15px 15px 0",
-                boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
-                height: "auto",
-                maxHeight: "calc(60vh)",
-              }}
+              className={`transition-all duration-500 ease-in-out overflow-hidden ${
+                topSidebarCollapsed ? "w-0 opacity-0" : "w-16 opacity-100"
+              } p-4`}
             >
-              {/* Menu Items */}
               <div className="overflow-y-auto hide-scrollbar">
                 <div className="flex flex-col items-center gap-3">
                   {topMenuItems.map((item, index) => (
@@ -162,24 +163,24 @@ export function SignupDualSidebar({
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* Top Section Toggle Button */}
-          <Button
-            onClick={toggleTopSidebar}
-            className="w-8 h-12 bg-[#1C2051] hover:bg-[#252B5C] border border-white/20 border-l-0 p-0 flex-shrink-0 z-10 transition-all duration-500 ease-in-out"
-            style={{
-              borderRadius: "0 15px 15px 0",
-              boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
-              marginLeft: topSidebarCollapsed ? "0" : "-8px",
-            }}
-          >
-            {topSidebarCollapsed ? (
-              <ChevronRight className="w-4 h-4 text-white transition-transform duration-300" />
-            ) : (
-              <ChevronLeft className="w-4 h-4 text-white transition-transform duration-300" />
-            )}
-          </Button>
+            {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
+            <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center">
+              <Button
+                onClick={toggleTopSidebar}
+                className="w-6 h-8 bg-[#252B5C] hover:bg-[#2A3175] border border-white/10 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"
+                style={{
+                  boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.3)",
+                }}
+              >
+                {topSidebarCollapsed ? (
+                  <ChevronRight className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
+                ) : (
+                  <ChevronLeft className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
+                )}
+              </Button>
+            </div>
+          </div>
         </div>
 
         {/* Bottom Sidebar Section */}

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -96,9 +96,9 @@ export function SignupDualSidebar({
   ];
 
   return (
-    <div className="fixed left-0 top-0 z-30 flex flex-col h-screen w-auto">
+    <div className="absolute left-0 top-32 z-30 flex flex-col w-auto">
       {/* Container with zero margin, aligned to left edge */}
-      <div className="flex flex-col gap-3 py-4 h-screen max-h-screen overflow-hidden mt-20">
+      <div className="flex flex-col gap-3 py-4 overflow-hidden">
         {/* Top Sidebar Section */}
         <div className="relative">
           <div

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -86,6 +86,15 @@ export function SignupDualSidebar({
     }
   };
 
+  // Dynamic bottom menu items based on selected companion
+  const dynamicBottomMenuItems = bottomMenuItems || [
+    {
+      src: selectedCompanion.image,
+      alt: selectedCompanion.name,
+      delay: 100
+    }
+  ];
+
   return (
     <div className="fixed left-0 top-0 z-30 flex flex-col h-screen w-auto">
       {/* Container with zero margin, aligned to left edge */}

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -93,7 +93,7 @@ export function SignupDualSidebar({
                         <img
                           src={item.src}
                           alt={item.alt}
-                          className="w-full h-full object-cover"
+                          className="w-full h-full object-cover transition-transform duration-300 group-hover:rotate-12"
                         />
                       </div>
 
@@ -170,7 +170,7 @@ export function SignupDualSidebar({
                         <img
                           src={item.src}
                           alt={item.alt}
-                          className="w-full h-full object-cover"
+                          className="w-full h-full object-cover transition-transform duration-300 group-hover:rotate-12"
                         />
                       </div>
 

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -254,16 +254,18 @@ export function SignupDualSidebar({
             <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center">
               <Button
                 onClick={toggleBottomSidebar}
-                className="w-6 h-8 bg-[#252B5C] hover:bg-[#2A3175] border border-white/10 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"
+                className="w-6 h-8 bg-transparent hover:bg-white/10 border-0 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"
                 style={{
-                  boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.3)",
+                  boxShadow: "none",
                 }}
               >
-                {bottomSidebarCollapsed ? (
-                  <ChevronRight className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
-                ) : (
-                  <ChevronLeft className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
-                )}
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F7504875ba38348f8bb8df1ca5aaf3464?format=webp&width=800"
+                  alt="Toggle"
+                  className={`w-4 h-4 object-contain transition-transform duration-300 group-hover:scale-125 ${
+                    bottomSidebarCollapsed ? "" : "rotate-180"
+                  }`}
+                />
               </Button>
             </div>
           </div>

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -98,7 +98,7 @@ export function SignupDualSidebar({
   return (
     <div className="fixed left-0 top-0 z-30 flex flex-col h-screen w-auto">
       {/* Container with zero margin, aligned to left edge */}
-      <div className="flex flex-col gap-3 py-4 h-screen max-h-screen overflow-hidden">
+      <div className="flex flex-col gap-3 py-4 h-screen max-h-screen overflow-hidden mt-20">
         {/* Top Sidebar Section */}
         <div className="flex items-center relative">
           {/* Top Section Content */}

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -1,0 +1,222 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface MenuItem {
+  src: string;
+  alt: string;
+  delay: number;
+}
+
+interface SignupDualSidebarProps {
+  topMenuItems?: MenuItem[];
+  bottomMenuItems?: MenuItem[];
+  onMenuItemClick?: (itemAlt: string, index: number) => void;
+}
+
+export function SignupDualSidebar({
+  topMenuItems = [
+    {
+      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F84c034c3c89947f78ee894fd36bda6a7?format=webp&width=800",
+      alt: "Adventure",
+      delay: 100
+    },
+    {
+      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F93b5b6d2e89c4bb59a80b993bd48c56b?format=webp&width=800",
+      alt: "Fantasy",
+      delay: 200
+    },
+    {
+      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F7c1e3f89a2b4456c97e2b8f3d5e9c7a4?format=webp&width=800",
+      alt: "Science",
+      delay: 300
+    }
+  ],
+  bottomMenuItems = [
+    {
+      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F5a2b8c3d4e5f6789012345678901234a?format=webp&width=800",
+      alt: "Settings",
+      delay: 100
+    },
+    {
+      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F8c7a6d5b4e3f2a109876543210fedcba?format=webp&width=800",
+      alt: "Help",
+      delay: 200
+    }
+  ],
+  onMenuItemClick,
+}: SignupDualSidebarProps) {
+  const [topSidebarCollapsed, setTopSidebarCollapsed] = useState(false);
+  const [bottomSidebarCollapsed, setBottomSidebarCollapsed] = useState(false);
+  const [showTopWaveEffect, setShowTopWaveEffect] = useState(true);
+  const [showBottomWaveEffect, setShowBottomWaveEffect] = useState(true);
+
+  const toggleTopSidebar = () => {
+    setTopSidebarCollapsed(!topSidebarCollapsed);
+  };
+
+  const toggleBottomSidebar = () => {
+    setBottomSidebarCollapsed(!bottomSidebarCollapsed);
+  };
+
+  return (
+    <div className="fixed left-0 top-0 z-30 flex flex-col h-screen w-auto">
+      {/* Container with zero margin, aligned to left edge */}
+      <div className="flex flex-col gap-3 py-4 h-screen max-h-screen overflow-hidden">
+        {/* Top Sidebar Section */}
+        <div className="flex items-center relative">
+          {/* Top Section Content */}
+          <div
+            className={`transition-all duration-500 ease-in-out overflow-hidden ${
+              topSidebarCollapsed ? "w-0 opacity-0" : "w-20 opacity-100"
+            }`}
+          >
+            <div
+              className="bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl flex flex-col p-4"
+              style={{
+                borderRadius: "0 15px 15px 0",
+                boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
+                height: "auto",
+                maxHeight: "calc(60vh)",
+              }}
+            >
+              {/* Menu Items */}
+              <div className="overflow-y-auto hide-scrollbar">
+                <div className="flex flex-col items-center gap-3">
+                  {topMenuItems.map((item, index) => (
+                    <div
+                      key={item.alt}
+                      className="relative group"
+                      style={{
+                        animation: showTopWaveEffect
+                          ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
+                          : "none",
+                        transform: showTopWaveEffect
+                          ? "scale(1)"
+                          : "scale(0)",
+                      }}
+                    >
+                      <div
+                        className="w-12 h-12 rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 hover:scale-110 hover:shadow-lg hover:ring-2 hover:ring-white/30 bg-white/5 hover:bg-white/15 backdrop-blur-sm border border-white/10 hover:border-white/30"
+                        onClick={() => onMenuItemClick?.(item.alt, index)}
+                      >
+                        <img
+                          src={item.src}
+                          alt={item.alt}
+                          className="w-full h-full object-cover"
+                        />
+                      </div>
+
+                      {/* Tooltip */}
+                      {!topSidebarCollapsed && (
+                        <div className="absolute left-full ml-3 top-1/2 -translate-y-1/2 px-3 py-2 bg-[#1C2051] border border-white/20 rounded-xl text-white text-xs font-medium whitespace-nowrap opacity-0 group-hover:opacity-100 transition-all duration-300 shadow-lg z-40 pointer-events-none">
+                          {item.alt}
+                          {/* Tooltip arrow */}
+                          <div className="absolute right-full top-1/2 -translate-y-1/2 w-0 h-0 border-t-4 border-b-4 border-r-4 border-transparent border-r-[#1C2051]"></div>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Top Section Toggle Button */}
+          <Button
+            onClick={toggleTopSidebar}
+            className="w-8 h-12 bg-[#1C2051] hover:bg-[#252B5C] border border-white/20 border-l-0 p-0 flex-shrink-0 z-10 transition-all duration-500 ease-in-out"
+            style={{
+              borderRadius: "0 15px 15px 0",
+              boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
+              marginLeft: topSidebarCollapsed ? "0" : "-8px",
+            }}
+          >
+            {topSidebarCollapsed ? (
+              <ChevronRight className="w-4 h-4 text-white transition-transform duration-300" />
+            ) : (
+              <ChevronLeft className="w-4 h-4 text-white transition-transform duration-300" />
+            )}
+          </Button>
+        </div>
+
+        {/* Bottom Sidebar Section */}
+        <div className="flex items-center relative">
+          {/* Bottom Section Content */}
+          <div
+            className={`transition-all duration-500 ease-in-out overflow-hidden ${
+              bottomSidebarCollapsed ? "w-0 opacity-0" : "w-20 opacity-100"
+            }`}
+          >
+            <div
+              className="bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl flex flex-col p-3"
+              style={{
+                borderRadius: "0 15px 15px 0",
+                boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
+                height: "auto",
+                maxHeight: "calc(30vh)",
+              }}
+            >
+              {/* Menu Items */}
+              <div className="overflow-y-auto hide-scrollbar">
+                <div className="flex flex-col items-center gap-2">
+                  {bottomMenuItems.map((item, index) => (
+                    <div
+                      key={item.alt}
+                      className="relative group"
+                      style={{
+                        animation: showBottomWaveEffect
+                          ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
+                          : "none",
+                        transform: showBottomWaveEffect
+                          ? "scale(1)"
+                          : "scale(0)",
+                      }}
+                    >
+                      <div
+                        className="w-12 h-12 rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 hover:scale-110 hover:shadow-lg hover:ring-2 hover:ring-white/30 bg-white/5 hover:bg-white/15 backdrop-blur-sm border border-white/10 hover:border-white/30"
+                        onClick={() => onMenuItemClick?.(item.alt, index)}
+                      >
+                        <img
+                          src={item.src}
+                          alt={item.alt}
+                          className="w-full h-full object-cover"
+                        />
+                      </div>
+
+                      {/* Tooltip */}
+                      {!bottomSidebarCollapsed && (
+                        <div className="absolute left-full ml-3 top-1/2 -translate-y-1/2 px-3 py-2 bg-[#1C2051] border border-white/20 rounded-xl text-white text-xs font-medium whitespace-nowrap opacity-0 group-hover:opacity-100 transition-all duration-300 shadow-lg z-40 pointer-events-none">
+                          {item.alt}
+                          {/* Tooltip arrow */}
+                          <div className="absolute right-full top-1/2 -translate-y-1/2 w-0 h-0 border-t-4 border-b-4 border-r-4 border-transparent border-r-[#1C2051]"></div>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Bottom Section Toggle Button */}
+          <Button
+            onClick={toggleBottomSidebar}
+            className="w-8 h-12 bg-[#1C2051] hover:bg-[#252B5C] border border-white/20 border-l-0 p-0 flex-shrink-0 z-10 transition-all duration-500 ease-in-out"
+            style={{
+              borderRadius: "0 15px 15px 0",
+              boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
+              marginLeft: bottomSidebarCollapsed ? "0" : "-8px",
+            }}
+          >
+            {bottomSidebarCollapsed ? (
+              <ChevronRight className="w-4 h-4 text-white transition-transform duration-300" />
+            ) : (
+              <ChevronLeft className="w-4 h-4 text-white transition-transform duration-300" />
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -26,8 +26,8 @@ export function SignupDualSidebar({
   ],
   bottomMenuItems = [
     {
-      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F39f348f7483547d18b45c8bfcdc8ad42?format=webp&width=800",
-      alt: "Selected Companion",
+      src: selectedCompanion.image,
+      alt: selectedCompanion.name,
       delay: 100
     }
   ],

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -168,16 +168,18 @@ export function SignupDualSidebar({
             <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center">
               <Button
                 onClick={toggleTopSidebar}
-                className="w-6 h-8 bg-[#252B5C] hover:bg-[#2A3175] border border-white/10 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"
+                className="w-6 h-8 bg-transparent hover:bg-white/10 border-0 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"
                 style={{
-                  boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.3)",
+                  boxShadow: "none",
                 }}
               >
-                {topSidebarCollapsed ? (
-                  <ChevronRight className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
-                ) : (
-                  <ChevronLeft className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
-                )}
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F7504875ba38348f8bb8df1ca5aaf3464?format=webp&width=800"
+                  alt="Toggle"
+                  className={`w-4 h-4 object-contain transition-transform duration-300 group-hover:scale-125 ${
+                    topSidebarCollapsed ? "" : "rotate-180"
+                  }`}
+                />
               </Button>
             </div>
           </div>

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -17,19 +17,9 @@ interface SignupDualSidebarProps {
 export function SignupDualSidebar({
   topMenuItems = [
     {
-      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F84c034c3c89947f78ee894fd36bda6a7?format=webp&width=800",
-      alt: "Adventure",
+      src: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F616e1bb5209e4aa1a9344292cfe45f71?format=webp&width=800",
+      alt: "Menu",
       delay: 100
-    },
-    {
-      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F93b5b6d2e89c4bb59a80b993bd48c56b?format=webp&width=800",
-      alt: "Fantasy",
-      delay: 200
-    },
-    {
-      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F7c1e3f89a2b4456c97e2b8f3d5e9c7a4?format=webp&width=800",
-      alt: "Science",
-      delay: 300
     }
   ],
   bottomMenuItems = [

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -39,6 +39,11 @@ export function SignupDualSidebar({
   const [showBottomWaveEffect, setShowBottomWaveEffect] = useState(true);
   const [isWheelModalOpen, setIsWheelModalOpen] = useState(false);
   const [isCompanionModalOpen, setIsCompanionModalOpen] = useState(false);
+  const [selectedCompanion, setSelectedCompanion] = useState({
+    id: "letsgo",
+    name: "Letsgo",
+    image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800"
+  });
 
   const toggleTopSidebar = () => {
     setTopSidebarCollapsed(!topSidebarCollapsed);

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -170,7 +170,13 @@ export function SignupDualSidebar({
                     >
                       <div
                         className="w-12 h-12 rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 hover:scale-110 hover:shadow-lg hover:ring-2 hover:ring-white/30 bg-white/5 hover:bg-white/15 backdrop-blur-sm border border-white/10 hover:border-white/30"
-                        onClick={() => onMenuItemClick?.(item.alt, index)}
+                        onClick={() => {
+                          if (item.alt === "Selected Companion") {
+                            setIsCompanionModalOpen(true);
+                          } else {
+                            onMenuItemClick?.(item.alt, index);
+                          }
+                        }}
                       >
                         <img
                           src={item.src}

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -41,6 +41,7 @@ export function SignupDualSidebar({
   const [bottomSidebarCollapsed, setBottomSidebarCollapsed] = useState(false);
   const [showTopWaveEffect, setShowTopWaveEffect] = useState(true);
   const [showBottomWaveEffect, setShowBottomWaveEffect] = useState(true);
+  const [isWheelModalOpen, setIsWheelModalOpen] = useState(false);
 
   const toggleTopSidebar = () => {
     setTopSidebarCollapsed(!topSidebarCollapsed);

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -53,6 +53,45 @@ export function SignupDualSidebar({
     setBottomSidebarCollapsed(!bottomSidebarCollapsed);
   };
 
+  // Companion mapping
+  const companionMapping = {
+    letsgo: {
+      name: "Letsgo",
+      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800"
+    },
+    rushmore: {
+      name: "Rushmore",
+      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800"
+    },
+    uni: {
+      name: "Uni",
+      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800"
+    },
+    cody: {
+      name: "Cody",
+      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800"
+    },
+    doma: {
+      name: "Doma",
+      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800"
+    },
+    rooty: {
+      name: "Rooty",
+      image: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800"
+    }
+  };
+
+  const handleCompanionSelect = (companionId: string) => {
+    const companion = companionMapping[companionId as keyof typeof companionMapping];
+    if (companion) {
+      setSelectedCompanion({
+        id: companionId,
+        name: companion.name,
+        image: companion.image
+      });
+    }
+  };
+
   return (
     <div className="fixed left-0 top-0 z-30 flex flex-col h-screen w-auto">
       {/* Container with zero margin, aligned to left edge */}

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -215,7 +215,7 @@ export function SignupDualSidebar({
                       <div
                         className="w-12 h-12 rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 hover:scale-110 hover:shadow-lg hover:ring-2 hover:ring-white/30 bg-white/5 hover:bg-white/15 backdrop-blur-sm border border-white/10 hover:border-white/30"
                         onClick={() => {
-                          if (item.alt === "Selected Companion") {
+                          if (item.alt === selectedCompanion.name || item.alt === "Selected Companion") {
                             setIsCompanionModalOpen(true);
                           } else {
                             onMenuItemClick?.(item.alt, index);

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -184,23 +184,24 @@ export function SignupDualSidebar({
         </div>
 
         {/* Bottom Sidebar Section */}
-        <div className="flex items-center relative">
-          {/* Bottom Section Content */}
+        <div className="relative">
           <div
-            className={`transition-all duration-500 ease-in-out overflow-hidden ${
-              bottomSidebarCollapsed ? "w-0 opacity-0" : "w-20 opacity-100"
+            className={`bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl transition-all duration-500 ease-in-out relative ${
+              bottomSidebarCollapsed ? "w-12" : "w-20"
             }`}
+            style={{
+              borderRadius: "0 15px 15px 0",
+              boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
+              height: "auto",
+              maxHeight: "calc(30vh)",
+            }}
           >
+            {/* Menu Items */}
             <div
-              className="bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl flex flex-col p-3"
-              style={{
-                borderRadius: "0 15px 15px 0",
-                boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
-                height: "auto",
-                maxHeight: "calc(30vh)",
-              }}
+              className={`transition-all duration-500 ease-in-out overflow-hidden ${
+                bottomSidebarCollapsed ? "w-0 opacity-0" : "w-16 opacity-100"
+              } p-3`}
             >
-              {/* Menu Items */}
               <div className="overflow-y-auto hide-scrollbar">
                 <div className="flex flex-col items-center gap-2">
                   {dynamicBottomMenuItems.map((item, index) => (
@@ -246,24 +247,24 @@ export function SignupDualSidebar({
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* Bottom Section Toggle Button */}
-          <Button
-            onClick={toggleBottomSidebar}
-            className="w-8 h-12 bg-[#1C2051] hover:bg-[#252B5C] border border-white/20 border-l-0 p-0 flex-shrink-0 z-10 transition-all duration-500 ease-in-out"
-            style={{
-              borderRadius: "0 15px 15px 0",
-              boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
-              marginLeft: bottomSidebarCollapsed ? "0" : "-8px",
-            }}
-          >
-            {bottomSidebarCollapsed ? (
-              <ChevronRight className="w-4 h-4 text-white transition-transform duration-300" />
-            ) : (
-              <ChevronLeft className="w-4 h-4 text-white transition-transform duration-300" />
-            )}
-          </Button>
+            {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
+            <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center">
+              <Button
+                onClick={toggleBottomSidebar}
+                className="w-6 h-8 bg-[#252B5C] hover:bg-[#2A3175] border border-white/10 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"
+                style={{
+                  boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.3)",
+                }}
+              >
+                {bottomSidebarCollapsed ? (
+                  <ChevronRight className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
+                ) : (
+                  <ChevronLeft className="w-3 h-3 text-white transition-transform duration-300 group-hover:scale-125" />
+                )}
+              </Button>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -202,7 +202,7 @@ export function SignupDualSidebar({
               {/* Menu Items */}
               <div className="overflow-y-auto hide-scrollbar">
                 <div className="flex flex-col items-center gap-2">
-                  {bottomMenuItems.map((item, index) => (
+                  {dynamicBottomMenuItems.map((item, index) => (
                     <div
                       key={item.alt}
                       className="relative group"

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -165,7 +165,7 @@ export function SignupDualSidebar({
             </div>
 
             {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
-            <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center">
+            <div className="absolute right-0.5 top-1/2 -translate-y-1/2 flex items-center justify-center">
               <Button
                 onClick={toggleTopSidebar}
                 className="w-6 h-8 bg-transparent hover:bg-white/10 border-0 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"
@@ -251,7 +251,7 @@ export function SignupDualSidebar({
             </div>
 
             {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
-            <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center">
+            <div className="absolute right-0.5 top-1/2 -translate-y-1/2 flex items-center justify-center">
               <Button
                 onClick={toggleBottomSidebar}
                 className="w-6 h-8 bg-transparent hover:bg-white/10 border-0 p-0 rounded-md transition-all duration-300 ease-in-out hover:scale-110 group"

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -90,7 +90,13 @@ export function SignupDualSidebar({
                     >
                       <div
                         className="w-12 h-12 rounded-2xl overflow-hidden cursor-pointer transition-all duration-300 hover:scale-110 hover:shadow-lg hover:ring-2 hover:ring-white/30 bg-white/5 hover:bg-white/15 backdrop-blur-sm border border-white/10 hover:border-white/30"
-                        onClick={() => onMenuItemClick?.(item.alt, index)}
+                        onClick={() => {
+                          if (item.alt === "Menu") {
+                            setIsWheelModalOpen(true);
+                          } else {
+                            onMenuItemClick?.(item.alt, index);
+                          }
+                        }}
                       >
                         <img
                           src={item.src}

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -25,14 +25,9 @@ export function SignupDualSidebar({
   ],
   bottomMenuItems = [
     {
-      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F5a2b8c3d4e5f6789012345678901234a?format=webp&width=800",
-      alt: "Settings",
+      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F39f348f7483547d18b45c8bfcdc8ad42?format=webp&width=800",
+      alt: "Selected Companion",
       delay: 100
-    },
-    {
-      src: "https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F8c7a6d5b4e3f2a109876543210fedcba?format=webp&width=800",
-      alt: "Help",
-      delay: 200
     }
   ],
   onMenuItemClick,

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -189,7 +189,7 @@ export function SignupDualSidebar({
         <div className="relative">
           <div
             className={`bg-[#1C2051] border border-white/20 border-l-0 shadow-2xl transition-all duration-500 ease-in-out relative ${
-              bottomSidebarCollapsed ? "w-12" : "w-20"
+              bottomSidebarCollapsed ? "w-8" : "w-20"
             }`}
             style={{
               borderRadius: "0 15px 15px 0",

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { TaleTreeWheelModal } from "./TaleTreeWheelModal";
 
 interface MenuItem {
   src: string;

--- a/client/components/signup/SignupDualSidebar.tsx
+++ b/client/components/signup/SignupDualSidebar.tsx
@@ -24,13 +24,7 @@ export function SignupDualSidebar({
       delay: 100
     }
   ],
-  bottomMenuItems = [
-    {
-      src: selectedCompanion.image,
-      alt: selectedCompanion.name,
-      delay: 100
-    }
-  ],
+  bottomMenuItems,
   onMenuItemClick,
 }: SignupDualSidebarProps) {
   const [topSidebarCollapsed, setTopSidebarCollapsed] = useState(false);

--- a/client/components/signup/SignupFooter.tsx
+++ b/client/components/signup/SignupFooter.tsx
@@ -1,0 +1,79 @@
+const SignupFooter = () => {
+  return (
+    <footer className="bg-indigo-900 text-white py-12 px-8">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex flex-col md:flex-row justify-between">
+          <div className="mb-8 md:mb-0">
+            <h4 className="text-xl font-bold mb-4">TaleTree Inc.</h4>
+            <p className="text-gray-300 text-sm">
+              149 Barrow St, Floor 2nd, New York, NY 10014, USA
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-8">
+            <div>
+              <h5 className="font-semibold mb-3">Company</h5>
+              <ul className="space-y-2 text-sm text-gray-300">
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Our Story
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Careers
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Contact
+                  </a>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <h5 className="font-semibold mb-3">Support</h5>
+              <ul className="space-y-2 text-sm text-gray-300">
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Getting Started
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Help Center
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Server Status
+                  </a>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <h5 className="font-semibold mb-3">Follow us</h5>
+              <div className="flex space-x-3">
+                <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+                <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+                <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+                <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-gray-700 mt-8 pt-6 text-center text-sm text-gray-400">
+          <p>
+            2024, TaleTree Inc. All rights reserved. | Email:
+            contact@taletree.com
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default SignupFooter;

--- a/client/components/signup/SignupNavigation.tsx
+++ b/client/components/signup/SignupNavigation.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/ui/button";
+
+const SignupNavigation = () => {
+  return (
+    <nav className="flex items-center justify-between p-4 relative z-10">
+      <div className="flex items-center space-x-2">
+        <div className="w-10 h-10 bg-cyan-400 rounded-full flex items-center justify-center">
+          <div className="w-6 h-6 bg-white rounded-full"></div>
+        </div>
+        <div>
+          <h1 className="text-white text-xl font-bold">taleTree</h1>
+          <p className="text-cyan-300 text-xs">
+            A New Kind of Curriculum for a New Kind of World
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center space-x-6">
+        <button className="text-white hover:text-cyan-300 transition-colors">
+          Features
+        </button>
+        <button className="text-white hover:text-cyan-300 transition-colors">
+          Pricing
+        </button>
+        <button className="text-white hover:text-cyan-300 transition-colors">
+          About
+        </button>
+        <Button className="bg-cyan-400 hover:bg-cyan-500 text-black rounded-full px-6">
+          Get Started
+        </Button>
+      </div>
+    </nav>
+  );
+};
+
+export default SignupNavigation;

--- a/client/components/signup/SpeechBubble.tsx
+++ b/client/components/signup/SpeechBubble.tsx
@@ -1,0 +1,17 @@
+interface SpeechBubbleProps {
+  message: string;
+}
+
+const SpeechBubble = ({ message }: SpeechBubbleProps) => {
+  return (
+    <div className="relative z-10 mb-8">
+      <div className="bg-cyan-400 rounded-2xl p-4 max-w-sm text-center relative">
+        <p className="text-black font-medium">{message}</p>
+        {/* Bubble tail */}
+        <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 w-4 h-4 bg-cyan-400 rotate-45"></div>
+      </div>
+    </div>
+  );
+};
+
+export default SpeechBubble;

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 
 interface WheelAction {

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -100,7 +100,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
 
   return (
     <div
-      className="fixed top-0 left-0 w-full h-full z-[60] flex items-center justify-center backdrop-blur-md bg-black/40"
+      className="fixed top-0 left-0 w-full h-full z-[9999] flex items-center justify-center backdrop-blur-md bg-black/40"
       onClick={onClose}
     >
       {/* Modal Content */}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -18,8 +18,6 @@ interface TaleTreeWheelModalProps {
 
 export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps) {
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [hoverTimeout, setHoverTimeout] = useState<NodeJS.Timeout | null>(null);
 
   // Calculate circular positions using trigonometry
   const radius = 150; // Radius of the circle

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -196,11 +196,14 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
             {/* Hover Description */}
             {hoveredAction && (
               <div
-                className="absolute z-30 transition-all duration-200 ease-in-out"
+                className={`absolute z-30 transition-all duration-300 ease-in-out ${
+                  showTooltip ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+                }`}
                 style={{
                   top: `calc(${getHoveredAction()?.position.top} - 80px)`,
                   left: getHoveredAction()?.position.left,
-                  transform: "translate(-50%, 0)"
+                  transform: "translate(-50%, 0)",
+                  pointerEvents: 'none' // Prevent tooltip from interfering with mouse events
                 }}
               >
                 <div className={`${getHoveredAction()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}>

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -94,30 +94,30 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       <div className="relative z-10 w-full h-full flex items-center justify-center p-4">
         <div className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col">
           {/* Header */}
-          <div className="flex justify-between items-center mb-4">
-            <div className="flex items-center gap-4">
-              <div className="w-8 h-8">
-                <img 
+          <div className="flex justify-between items-start mb-6">
+            <div className="flex items-center gap-3">
+              <div className="w-6 h-6">
+                <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
                   alt="TaleTree Logo"
                   className="w-full h-full object-contain"
                 />
               </div>
-              <span className="text-white text-sm bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
+              <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
                 The TaleTree Method
               </span>
             </div>
             <button
               onClick={onClose}
-              className="w-10 h-10 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200"
+              className="w-8 h-8 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200"
             >
-              <X className="w-5 h-5 text-white" />
+              <X className="w-4 h-4 text-white" />
             </button>
           </div>
 
           {/* Main Title */}
-          <div className="text-center mb-8">
-            <h1 className="text-4xl md:text-5xl font-bold text-white mb-2">
+          <div className="text-center mb-12">
+            <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
               Welcome to TaleTree
             </h1>
           </div>

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -164,8 +164,12 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
               >
                 <div className="flex flex-col items-center">
                   {/* Action Circle */}
-                  <div className={`w-16 h-16 ${action.color} rounded-full flex items-center justify-center text-2xl hover:scale-110 transition-transform duration-200 shadow-lg`}>
-                    {action.icon}
+                  <div className={`w-16 h-16 ${action.color} rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-200 shadow-lg overflow-hidden`}>
+                    <img
+                      src={action.icon}
+                      alt={action.label}
+                      className="w-8 h-8 object-contain"
+                    />
                   </div>
                   {/* Label */}
                   <span className="text-white text-sm font-medium mt-2 bg-black/30 px-2 py-1 rounded-md backdrop-blur-sm">

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -99,23 +99,15 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50">
-      {/* Backdrop with hero background blurred */}
-      <div
-        className="absolute inset-0 bg-cover bg-center backdrop-blur-md"
-        style={{
-          backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
-          filter: 'blur(8px)'
-        }}
-        onClick={onClose}
-      />
-
-      {/* Dark overlay */}
-      <div className="absolute inset-0 bg-black/30" />
-
+    <div
+      className="fixed top-0 left-0 w-full h-full z-[60] flex items-center justify-center backdrop-blur-md bg-black/40"
+      onClick={onClose}
+    >
       {/* Modal Content */}
-      <div className="relative z-10 w-full h-full flex items-center justify-center p-4">
-        <div className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col">
+      <div
+        className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col p-4"
+        onClick={(e) => e.stopPropagation()}
+      >
           {/* Header */}
           <div className="flex justify-center items-center mb-6">
             <div className="flex items-center gap-3">
@@ -192,9 +184,8 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
                 </div>
               </div>
             )}
-          </div>
         </div>
-      </div>
+    </div>
     </div>
   );
 }

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -117,7 +117,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       <div className="relative z-10 w-full h-full flex items-center justify-center p-4">
         <div className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col">
           {/* Header */}
-          <div className="flex justify-between items-start mb-6">
+          <div className="flex justify-center items-center mb-6">
             <div className="flex items-center gap-3">
               <div className="w-6 h-6">
                 <img
@@ -130,12 +130,6 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
                 The TaleTree Method
               </span>
             </div>
-            <button
-              onClick={onClose}
-              className="w-8 h-8 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200"
-            >
-              <X className="w-4 h-4 text-white" />
-            </button>
           </div>
 
           {/* Main Title */}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -191,4 +191,6 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     </div>
     </div>
   );
+
+  return createPortal(modalContent, document.body);
 }

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -99,7 +99,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
 
   if (!isOpen) return null;
 
-  return (
+  const modalContent = (
     <div
       className="fixed top-0 left-0 w-full h-full z-[99999] flex items-center justify-center backdrop-blur-md bg-black/40"
       onClick={onClose}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+
+interface WheelAction {
+  id: string;
+  icon: string;
+  label: string;
+  color: string;
+  description: string;
+  position: { top: string; left: string };
+}
+
+interface TaleTreeWheelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps) {
+  const [hoveredAction, setHoveredAction] = useState<string | null>(null);
+
+  const wheelActions: WheelAction[] = [
+    {
+      id: "imagine",
+      icon: "💡",
+      label: "Imagine",
+      color: "bg-orange-500",
+      description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet vel lectus sed varius.",
+      position: { top: "15%", left: "50%" }
+    },
+    {
+      id: "play",
+      icon: "🎮",
+      label: "Play",
+      color: "bg-blue-500",
+      description: "Engage in interactive storytelling and creative play activities.",
+      position: { top: "25%", left: "70%" }
+    },
+    {
+      id: "create",
+      icon: "✨",
+      label: "Create",
+      color: "bg-cyan-500",
+      description: "Build and craft your own stories and creative content.",
+      position: { top: "55%", left: "75%" }
+    },
+    {
+      id: "store",
+      icon: "📚",
+      label: "Store",
+      color: "bg-green-500",
+      description: "Save and organize your creative works and stories.",
+      position: { top: "75%", left: "55%" }
+    },
+    {
+      id: "reflect",
+      icon: "🧠",
+      label: "Reflect",
+      color: "bg-purple-500",
+      description: "Think about your learning journey and growth.",
+      position: { top: "55%", left: "25%" }
+    },
+    {
+      id: "reward",
+      icon: "❤️",
+      label: "Reward",
+      color: "bg-pink-500",
+      description: "Celebrate achievements and milestones in your journey.",
+      position: { top: "25%", left: "30%" }
+    }
+  ];
+
+  const getHoveredAction = () => {
+    return wheelActions.find(action => action.id === hoveredAction);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div 
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      
+      {/* Modal Content */}
+      <div className="relative w-full max-w-4xl h-full max-h-[80vh] mx-4">
+        {/* Background with same image as hero section but blurred */}
+        <div 
+          className="absolute inset-0 rounded-3xl bg-cover bg-center"
+          style={{
+            backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
+            filter: 'blur(2px)'
+          }}
+        />
+        
+        {/* Dark overlay */}
+        <div className="absolute inset-0 bg-black/40 rounded-3xl" />
+        
+        {/* Content */}
+        <div className="relative z-10 w-full h-full p-8 flex flex-col">
+          {/* Header */}
+          <div className="flex justify-between items-center mb-4">
+            <div className="flex items-center gap-4">
+              <div className="w-8 h-8">
+                <img 
+                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
+                  alt="TaleTree Logo"
+                  className="w-full h-full object-contain"
+                />
+              </div>
+              <span className="text-white text-sm bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
+                The TaleTree Method
+              </span>
+            </div>
+            <button
+              onClick={onClose}
+              className="w-10 h-10 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200"
+            >
+              <X className="w-5 h-5 text-white" />
+            </button>
+          </div>
+
+          {/* Main Title */}
+          <div className="text-center mb-8">
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-2">
+              Welcome to TaleTree
+            </h1>
+          </div>
+
+          {/* Wheel Container */}
+          <div className="flex-1 relative">
+            {/* Action Items */}
+            {wheelActions.map((action) => (
+              <div
+                key={action.id}
+                className="absolute transform -translate-x-1/2 -translate-y-1/2 cursor-pointer"
+                style={{
+                  top: action.position.top,
+                  left: action.position.left
+                }}
+                onMouseEnter={() => setHoveredAction(action.id)}
+                onMouseLeave={() => setHoveredAction(null)}
+              >
+                <div className="flex flex-col items-center">
+                  {/* Action Circle */}
+                  <div className={`w-16 h-16 ${action.color} rounded-full flex items-center justify-center text-2xl hover:scale-110 transition-transform duration-200 shadow-lg`}>
+                    {action.icon}
+                  </div>
+                  {/* Label */}
+                  <span className="text-white text-sm font-medium mt-2 bg-black/30 px-2 py-1 rounded-md backdrop-blur-sm">
+                    {action.label}
+                  </span>
+                </div>
+              </div>
+            ))}
+
+            {/* Hover Description */}
+            {hoveredAction && (
+              <div className="absolute top-1/4 left-1/4 transform -translate-x-1/2">
+                <div className="bg-pink-500 text-white p-4 rounded-xl max-w-xs shadow-xl">
+                  <p className="text-sm leading-relaxed">
+                    {getHoveredAction()?.description}
+                  </p>
+                  {/* Tooltip arrow */}
+                  <div className="absolute top-full left-8 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-pink-500"></div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -97,34 +97,6 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     return wheelActions.find(action => action.id === hoveredAction);
   };
 
-  const handleMouseEnter = (actionId: string) => {
-    // Clear any existing timeout
-    if (hoverTimeout) {
-      clearTimeout(hoverTimeout);
-    }
-
-    setHoveredAction(actionId);
-    // Show tooltip after a small delay
-    const timeout = setTimeout(() => {
-      setShowTooltip(true);
-    }, 300);
-    setHoverTimeout(timeout);
-  };
-
-  const handleMouseLeave = () => {
-    // Clear timeout
-    if (hoverTimeout) {
-      clearTimeout(hoverTimeout);
-      setHoverTimeout(null);
-    }
-
-    // Hide tooltip immediately but keep hovered action for a moment
-    setShowTooltip(false);
-    setTimeout(() => {
-      setHoveredAction(null);
-    }, 150);
-  };
-
   if (!isOpen) return null;
 
   const modalContent = (

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -146,15 +146,29 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
           </div>
 
           {/* Wheel Container */}
-          <div className="flex-1 relative">
-            {/* Action Items */}
+          <div className="flex-1 relative flex items-center justify-center">
+            {/* Center Close Button */}
+            <button
+              onClick={onClose}
+              className="absolute w-16 h-16 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200 shadow-lg z-20"
+              style={{
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)"
+              }}
+            >
+              <X className="w-8 h-8 text-white" />
+            </button>
+
+            {/* Action Items - Circular Layout */}
             {wheelActions.map((action) => (
               <div
                 key={action.id}
-                className="absolute transform -translate-x-1/2 -translate-y-1/2 cursor-pointer"
+                className="absolute cursor-pointer"
                 style={{
                   top: action.position.top,
-                  left: action.position.left
+                  left: action.position.left,
+                  transform: "translate(-50%, -50%)"
                 }}
                 onMouseEnter={() => setHoveredAction(action.id)}
                 onMouseLeave={() => setHoveredAction(null)}
@@ -174,8 +188,8 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
 
             {/* Hover Description */}
             {hoveredAction && (
-              <div className="absolute top-20 left-12">
-                <div className="bg-pink-500 text-white p-3 rounded-lg max-w-xs shadow-xl">
+              <div className="absolute top-16 left-16">
+                <div className="bg-pink-500 text-white p-3 rounded-lg max-w-xs shadow-xl z-30">
                   <p className="text-xs leading-relaxed">
                     {getHoveredAction()?.description}
                   </p>

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -163,16 +163,16 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
                 onMouseLeave={() => setHoveredAction(null)}
               >
                 <div className="flex flex-col items-center">
-                  {/* Action Circle */}
-                  <div className={`w-16 h-16 ${action.color} rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-200 shadow-lg overflow-hidden`}>
+                  {/* Action Icon */}
+                  <div className="flex items-center justify-center hover:scale-110 transition-transform duration-200">
                     <img
                       src={action.icon}
                       alt={action.label}
-                      className="w-8 h-8 object-contain"
+                      className="w-16 h-16 object-contain"
                     />
                   </div>
                   {/* Label */}
-                  <span className="text-white text-sm font-medium mt-2 bg-black/30 px-2 py-1 rounded-md backdrop-blur-sm">
+                  <span className="text-white text-sm font-medium mt-2 bg-black/50 px-3 py-1 rounded-full backdrop-blur-sm">
                     {action.label}
                   </span>
                 </div>

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -27,7 +27,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
   const wheelActions: WheelAction[] = [
     {
       id: "imagine",
-      icon: "💡",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fbe8068e94c034f37b80ff496f9836079?format=webp&width=800",
       label: "Imagine",
       color: "bg-orange-500",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet vel lectus sed varius.",
@@ -38,7 +38,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     },
     {
       id: "play",
-      icon: "🎮",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F392f37f775f74478ab0ebdf2db3f8b18?format=webp&width=800",
       label: "Play",
       color: "bg-blue-500",
       description: "Engage in interactive storytelling and creative play activities.",
@@ -49,7 +49,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     },
     {
       id: "create",
-      icon: "✨",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F084deab3e0e14195a8bd0e2f6adf11a8?format=webp&width=800",
       label: "Create",
       color: "bg-cyan-500",
       description: "Build and craft your own stories and creative content.",
@@ -60,7 +60,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     },
     {
       id: "store",
-      icon: "📚",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff5ca235dac1145ad9e9f34e3ffb685b1?format=webp&width=800",
       label: "Store",
       color: "bg-green-500",
       description: "Save and organize your creative works and stories.",
@@ -71,7 +71,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     },
     {
       id: "reflect",
-      icon: "🧠",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F84bf40f92efe4b4ea397148088e0ce03?format=webp&width=800",
       label: "Reflect",
       color: "bg-purple-500",
       description: "Think about your learning journey and growth.",
@@ -82,7 +82,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     },
     {
       id: "reward",
-      icon: "❤️",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F2728d898d1bb4efabee72f00d281e7cf?format=webp&width=800",
       label: "Reward",
       color: "bg-pink-500",
       description: "Celebrate achievements and milestones in your journey.",

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -113,25 +113,9 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       >
           {/* Header */}
           <div className="flex justify-center items-center mb-6">
-            <div className="flex items-center gap-3">
-              <div className="w-6 h-6">
-                <img
-                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
-                  alt="TaleTree Logo"
-                  className="w-full h-full object-contain"
-                />
-              </div>
-              <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
-                The TaleTree Method
-              </span>
-            </div>
-          </div>
-
-          {/* Main Title */}
-          <div className="text-center mb-12">
-            <h1 className="text-3xl md:text-4xl font-bold text-white mb-2">
-              Welcome to TaleTree
-            </h1>
+            <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
+              The TaleTree Method
+            </span>
           </div>
 
           {/* Wheel Container */}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -173,8 +173,8 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
                   left: action.position.left,
                   transform: "translate(-50%, -50%)"
                 }}
-                onMouseEnter={() => setHoveredAction(action.id)}
-                onMouseLeave={() => setHoveredAction(null)}
+                onMouseEnter={() => handleMouseEnter(action.id)}
+                onMouseLeave={handleMouseLeave}
               >
                 <div className="flex flex-col items-center">
                   {/* Action Icon */}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -76,29 +76,23 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop */}
-      <div 
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+    <div className="fixed inset-0 z-50">
+      {/* Backdrop with hero background blurred */}
+      <div
+        className="absolute inset-0 bg-cover bg-center backdrop-blur-md"
+        style={{
+          backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
+          filter: 'blur(8px)'
+        }}
         onClick={onClose}
       />
-      
+
+      {/* Dark overlay */}
+      <div className="absolute inset-0 bg-black/30" />
+
       {/* Modal Content */}
-      <div className="relative w-full max-w-4xl h-full max-h-[80vh] mx-4">
-        {/* Background with same image as hero section but blurred */}
-        <div 
-          className="absolute inset-0 rounded-3xl bg-cover bg-center"
-          style={{
-            backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
-            filter: 'blur(2px)'
-          }}
-        />
-        
-        {/* Dark overlay */}
-        <div className="absolute inset-0 bg-black/40 rounded-3xl" />
-        
-        {/* Content */}
-        <div className="relative z-10 w-full h-full p-8 flex flex-col">
+      <div className="relative z-10 w-full h-full flex items-center justify-center p-4">
+        <div className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col">
           {/* Header */}
           <div className="flex justify-between items-center mb-4">
             <div className="flex items-center gap-4">

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -166,14 +166,12 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
             {/* Hover Description */}
             {hoveredAction && (
               <div
-                className={`absolute z-30 transition-all duration-300 ease-in-out ${
-                  showTooltip ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
-                }`}
+                className="absolute z-30 transition-opacity duration-150 ease-in-out opacity-100"
                 style={{
                   top: `calc(${getHoveredAction()?.position.top} - 80px)`,
                   left: getHoveredAction()?.position.left,
                   transform: "translate(-50%, 0)",
-                  pointerEvents: 'none' // Prevent tooltip from interfering with mouse events
+                  pointerEvents: 'none'
                 }}
               >
                 <div className={`${getHoveredAction()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}>

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -156,7 +156,7 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
                     />
                   </div>
                   {/* Label */}
-                  <span className="text-white text-sm font-medium mt-2 bg-black/50 px-3 py-1 rounded-full backdrop-blur-sm">
+                  <span className={`text-white text-sm font-medium mt-2 ${action.color} px-3 py-1 rounded-full`}>
                     {action.label}
                   </span>
                 </div>

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -143,8 +143,8 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
                   left: action.position.left,
                   transform: "translate(-50%, -50%)"
                 }}
-                onMouseEnter={() => handleMouseEnter(action.id)}
-                onMouseLeave={handleMouseLeave}
+                onMouseEnter={() => setHoveredAction(action.id)}
+                onMouseLeave={() => setHoveredAction(null)}
               >
                 <div className="flex flex-col items-center">
                   {/* Action Icon */}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -99,6 +99,34 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     return wheelActions.find(action => action.id === hoveredAction);
   };
 
+  const handleMouseEnter = (actionId: string) => {
+    // Clear any existing timeout
+    if (hoverTimeout) {
+      clearTimeout(hoverTimeout);
+    }
+
+    setHoveredAction(actionId);
+    // Show tooltip after a small delay
+    const timeout = setTimeout(() => {
+      setShowTooltip(true);
+    }, 300);
+    setHoverTimeout(timeout);
+  };
+
+  const handleMouseLeave = () => {
+    // Clear timeout
+    if (hoverTimeout) {
+      clearTimeout(hoverTimeout);
+      setHoverTimeout(null);
+    }
+
+    // Hide tooltip immediately but keep hovered action for a moment
+    setShowTooltip(false);
+    setTimeout(() => {
+      setHoveredAction(null);
+    }, 150);
+  };
+
   if (!isOpen) return null;
 
   const modalContent = (

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -106,8 +106,9 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
     >
       {/* Modal Content */}
       <div
-        className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col p-4"
+        className="w-full max-w-5xl h-full max-h-[90vh] flex flex-col p-4 relative z-[99999]"
         onClick={(e) => e.stopPropagation()}
+        style={{ zIndex: 99999 }}
       >
           {/* Header */}
           <div className="flex justify-center items-center mb-6">

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -16,7 +16,10 @@ interface TaleTreeWheelModalProps {
   onClose: () => void;
 }
 
-export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps) {
+export function TaleTreeWheelModal({
+  isOpen,
+  onClose,
+}: TaleTreeWheelModalProps) {
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
 
   // Calculate circular positions using trigonometry
@@ -30,22 +33,24 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fbe8068e94c034f37b80ff496f9836079?format=webp&width=800",
       label: "Imagine",
       color: "bg-orange-500",
-      description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet vel lectus sed varius.",
+      description:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet vel lectus sed varius.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/2)}px)`, // -90° (top)
-        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/2)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 2)}px)`,
+      },
     },
     {
       id: "play",
       icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F392f37f775f74478ab0ebdf2db3f8b18?format=webp&width=800",
       label: "Play",
       color: "bg-blue-500",
-      description: "Engage in interactive storytelling and creative play activities.",
+      description:
+        "Engage in interactive storytelling and creative play activities.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/6)}px)`, // -30° (top right)
-        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/6)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 6)}px)`,
+      },
     },
     {
       id: "create",
@@ -54,9 +59,9 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       color: "bg-cyan-500",
       description: "Build and craft your own stories and creative content.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/6)}px)`, // 30° (bottom right)
-        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/6)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 6)}px)`,
+      },
     },
     {
       id: "store",
@@ -65,9 +70,9 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       color: "bg-green-500",
       description: "Save and organize your creative works and stories.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/2)}px)`, // 90° (bottom)
-        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/2)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 2)}px)`,
+      },
     },
     {
       id: "reflect",
@@ -76,9 +81,9 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       color: "bg-purple-500",
       description: "Think about your learning journey and growth.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(5*Math.PI/6)}px)`, // 150° (bottom left)
-        left: `calc(50% + ${centerX + radius * Math.cos(5*Math.PI/6)}px)`
-      }
+        top: `calc(50% + ${centerY + radius * Math.sin((5 * Math.PI) / 6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos((5 * Math.PI) / 6)}px)`,
+      },
     },
     {
       id: "reward",
@@ -87,14 +92,14 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       color: "bg-pink-500",
       description: "Celebrate achievements and milestones in your journey.",
       position: {
-        top: `calc(50% + ${centerY + radius * Math.sin(-5*Math.PI/6)}px)`, // -150° (top left)
-        left: `calc(50% + ${centerX + radius * Math.cos(-5*Math.PI/6)}px)`
-      }
-    }
+        top: `calc(50% + ${centerY + radius * Math.sin((-5 * Math.PI) / 6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos((-5 * Math.PI) / 6)}px)`,
+      },
+    },
   ];
 
   const getHoveredAction = () => {
-    return wheelActions.find(action => action.id === hoveredAction);
+    return wheelActions.find((action) => action.id === hoveredAction);
   };
 
   if (!isOpen) return null;
@@ -111,90 +116,102 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
         onClick={(e) => e.stopPropagation()}
         style={{ zIndex: 99999 }}
       >
-          {/* Header */}
-          <div className="flex justify-center items-center mb-6">
-            <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
-              The TaleTree Method
-            </span>
-          </div>
+        {/* Header */}
+        <div className="flex justify-center items-center mb-6">
+          <span className="text-white text-xs bg-white/20 px-3 py-1 rounded-full backdrop-blur-sm">
+            The TaleTree Method
+          </span>
+        </div>
 
-          {/* Wheel Container */}
-          <div className="flex-1 relative flex items-center justify-center">
-            {/* Center Close Button */}
-            <button
-              onClick={onClose}
-              className="absolute w-16 h-16 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200 shadow-lg z-20"
+        {/* Wheel Container */}
+        <div className="flex-1 relative flex items-center justify-center">
+          {/* Center Close Button */}
+          <button
+            onClick={onClose}
+            className="absolute w-16 h-16 bg-red-500 hover:bg-red-600 rounded-full flex items-center justify-center transition-colors duration-200 shadow-lg z-20"
+            style={{
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+            }}
+          >
+            <X className="w-8 h-8 text-white" />
+          </button>
+
+          {/* Action Items - Circular Layout */}
+          {wheelActions.map((action) => (
+            <div
+              key={action.id}
+              className="absolute cursor-pointer"
               style={{
-                top: "50%",
-                left: "50%",
-                transform: "translate(-50%, -50%)"
+                top: action.position.top,
+                left: action.position.left,
+                transform: "translate(-50%, -50%)",
+              }}
+              onMouseEnter={() => setHoveredAction(action.id)}
+              onMouseLeave={() => setHoveredAction(null)}
+            >
+              <div className="flex flex-col items-center">
+                {/* Action Icon */}
+                <div className="flex items-center justify-center hover:scale-110 transition-transform duration-200">
+                  <img
+                    src={action.icon}
+                    alt={action.label}
+                    className="w-16 h-16 object-contain"
+                  />
+                </div>
+                {/* Label */}
+                <span
+                  className={`text-white text-sm font-medium mt-2 ${action.color} px-3 py-1 rounded-full`}
+                >
+                  {action.label}
+                </span>
+              </div>
+            </div>
+          ))}
+
+          {/* Hover Description */}
+          {hoveredAction && (
+            <div
+              className="absolute z-30 transition-opacity duration-150 ease-in-out opacity-100"
+              style={{
+                top: `calc(${getHoveredAction()?.position.top} - 80px)`,
+                left: getHoveredAction()?.position.left,
+                transform: "translate(-50%, 0)",
+                pointerEvents: "none",
               }}
             >
-              <X className="w-8 h-8 text-white" />
-            </button>
-
-            {/* Action Items - Circular Layout */}
-            {wheelActions.map((action) => (
               <div
-                key={action.id}
-                className="absolute cursor-pointer"
-                style={{
-                  top: action.position.top,
-                  left: action.position.left,
-                  transform: "translate(-50%, -50%)"
-                }}
-                onMouseEnter={() => setHoveredAction(action.id)}
-                onMouseLeave={() => setHoveredAction(null)}
+                className={`${getHoveredAction()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}
               >
-                <div className="flex flex-col items-center">
-                  {/* Action Icon */}
-                  <div className="flex items-center justify-center hover:scale-110 transition-transform duration-200">
-                    <img
-                      src={action.icon}
-                      alt={action.label}
-                      className="w-16 h-16 object-contain"
-                    />
-                  </div>
-                  {/* Label */}
-                  <span className={`text-white text-sm font-medium mt-2 ${action.color} px-3 py-1 rounded-full`}>
-                    {action.label}
-                  </span>
-                </div>
+                <p className="text-xs leading-relaxed">
+                  {getHoveredAction()?.description}
+                </p>
+                {/* Tooltip arrow with matching color */}
+                <div
+                  className={`absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent`}
+                  style={{
+                    borderTopColor:
+                      getHoveredAction()?.color === "bg-orange-500"
+                        ? "#f97316"
+                        : getHoveredAction()?.color === "bg-blue-500"
+                          ? "#3b82f6"
+                          : getHoveredAction()?.color === "bg-cyan-500"
+                            ? "#06b6d4"
+                            : getHoveredAction()?.color === "bg-green-500"
+                              ? "#22c55e"
+                              : getHoveredAction()?.color === "bg-purple-500"
+                                ? "#a855f7"
+                                : getHoveredAction()?.color === "bg-pink-500"
+                                  ? "#ec4899"
+                                  : "#ec4899",
+                  }}
+                ></div>
               </div>
-            ))}
-
-            {/* Hover Description */}
-            {hoveredAction && (
-              <div
-                className="absolute z-30 transition-opacity duration-150 ease-in-out opacity-100"
-                style={{
-                  top: `calc(${getHoveredAction()?.position.top} - 80px)`,
-                  left: getHoveredAction()?.position.left,
-                  transform: "translate(-50%, 0)",
-                  pointerEvents: 'none'
-                }}
-              >
-                <div className={`${getHoveredAction()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}>
-                  <p className="text-xs leading-relaxed">
-                    {getHoveredAction()?.description}
-                  </p>
-                  {/* Tooltip arrow with matching color */}
-                  <div
-                    className={`absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent`}
-                    style={{
-                      borderTopColor: getHoveredAction()?.color === 'bg-orange-500' ? '#f97316' :
-                                    getHoveredAction()?.color === 'bg-blue-500' ? '#3b82f6' :
-                                    getHoveredAction()?.color === 'bg-cyan-500' ? '#06b6d4' :
-                                    getHoveredAction()?.color === 'bg-green-500' ? '#22c55e' :
-                                    getHoveredAction()?.color === 'bg-purple-500' ? '#a855f7' :
-                                    getHoveredAction()?.color === 'bg-pink-500' ? '#ec4899' : '#ec4899'
-                    }}
-                  ></div>
-                </div>
-              </div>
-            )}
+            </div>
+          )}
         </div>
-    </div>
+      </div>
     </div>
   );
 

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -166,19 +166,29 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
             {/* Hover Description */}
             {hoveredAction && (
               <div
-                className="absolute z-30"
+                className="absolute z-30 transition-all duration-200 ease-in-out"
                 style={{
                   top: `calc(${getHoveredAction()?.position.top} - 80px)`,
                   left: getHoveredAction()?.position.left,
                   transform: "translate(-50%, 0)"
                 }}
               >
-                <div className="bg-pink-500 text-white p-3 rounded-lg max-w-xs shadow-xl">
+                <div className={`${getHoveredAction()?.color} text-white p-3 rounded-lg max-w-xs shadow-xl`}>
                   <p className="text-xs leading-relaxed">
                     {getHoveredAction()?.description}
                   </p>
-                  {/* Tooltip arrow */}
-                  <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent border-t-pink-500"></div>
+                  {/* Tooltip arrow with matching color */}
+                  <div
+                    className={`absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent`}
+                    style={{
+                      borderTopColor: getHoveredAction()?.color === 'bg-orange-500' ? '#f97316' :
+                                    getHoveredAction()?.color === 'bg-blue-500' ? '#3b82f6' :
+                                    getHoveredAction()?.color === 'bg-cyan-500' ? '#06b6d4' :
+                                    getHoveredAction()?.color === 'bg-green-500' ? '#22c55e' :
+                                    getHoveredAction()?.color === 'bg-purple-500' ? '#a855f7' :
+                                    getHoveredAction()?.color === 'bg-pink-500' ? '#ec4899' : '#ec4899'
+                    }}
+                  ></div>
                 </div>
               </div>
             )}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -151,13 +151,13 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
 
             {/* Hover Description */}
             {hoveredAction && (
-              <div className="absolute top-1/4 left-1/4 transform -translate-x-1/2">
-                <div className="bg-pink-500 text-white p-4 rounded-xl max-w-xs shadow-xl">
-                  <p className="text-sm leading-relaxed">
+              <div className="absolute top-20 left-12">
+                <div className="bg-pink-500 text-white p-3 rounded-lg max-w-xs shadow-xl">
+                  <p className="text-xs leading-relaxed">
                     {getHoveredAction()?.description}
                   </p>
                   {/* Tooltip arrow */}
-                  <div className="absolute top-full left-8 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-pink-500"></div>
+                  <div className="absolute top-full left-6 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent border-t-pink-500"></div>
                 </div>
               </div>
             )}

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -100,8 +100,9 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
 
   return (
     <div
-      className="fixed top-0 left-0 w-full h-full z-[9999] flex items-center justify-center backdrop-blur-md bg-black/40"
+      className="fixed top-0 left-0 w-full h-full z-[99999] flex items-center justify-center backdrop-blur-md bg-black/40"
       onClick={onClose}
+      style={{ zIndex: 99999 }}
     >
       {/* Modal Content */}
       <div

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -18,6 +18,11 @@ interface TaleTreeWheelModalProps {
 export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps) {
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
 
+  // Calculate circular positions using trigonometry
+  const radius = 150; // Radius of the circle
+  const centerX = 0; // Center X (will be positioned relative to container center)
+  const centerY = 0; // Center Y (will be positioned relative to container center)
+
   const wheelActions: WheelAction[] = [
     {
       id: "imagine",
@@ -25,7 +30,10 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       label: "Imagine",
       color: "bg-orange-500",
       description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet vel lectus sed varius.",
-      position: { top: "15%", left: "50%" }
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/2)}px)`
+      }
     },
     {
       id: "play",
@@ -33,7 +41,10 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       label: "Play",
       color: "bg-blue-500",
       description: "Engage in interactive storytelling and creative play activities.",
-      position: { top: "25%", left: "70%" }
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI/6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI/6)}px)`
+      }
     },
     {
       id: "create",
@@ -41,7 +52,10 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       label: "Create",
       color: "bg-cyan-500",
       description: "Build and craft your own stories and creative content.",
-      position: { top: "55%", left: "75%" }
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/6)}px)`
+      }
     },
     {
       id: "store",
@@ -49,7 +63,10 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       label: "Store",
       color: "bg-green-500",
       description: "Save and organize your creative works and stories.",
-      position: { top: "75%", left: "55%" }
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI/2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI/2)}px)`
+      }
     },
     {
       id: "reflect",
@@ -57,7 +74,10 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       label: "Reflect",
       color: "bg-purple-500",
       description: "Think about your learning journey and growth.",
-      position: { top: "55%", left: "25%" }
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(5*Math.PI/6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos(5*Math.PI/6)}px)`
+      }
     },
     {
       id: "reward",
@@ -65,7 +85,10 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
       label: "Reward",
       color: "bg-pink-500",
       description: "Celebrate achievements and milestones in your journey.",
-      position: { top: "25%", left: "30%" }
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-5*Math.PI/6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos(-5*Math.PI/6)}px)`
+      }
     }
   ];
 

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -18,6 +18,8 @@ interface TaleTreeWheelModalProps {
 
 export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps) {
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [hoverTimeout, setHoverTimeout] = useState<NodeJS.Timeout | null>(null);
 
   // Calculate circular positions using trigonometry
   const radius = 150; // Radius of the circle

--- a/client/components/signup/TaleTreeWheelModal.tsx
+++ b/client/components/signup/TaleTreeWheelModal.tsx
@@ -165,13 +165,20 @@ export function TaleTreeWheelModal({ isOpen, onClose }: TaleTreeWheelModalProps)
 
             {/* Hover Description */}
             {hoveredAction && (
-              <div className="absolute top-16 left-16">
-                <div className="bg-pink-500 text-white p-3 rounded-lg max-w-xs shadow-xl z-30">
+              <div
+                className="absolute z-30"
+                style={{
+                  top: `calc(${getHoveredAction()?.position.top} - 80px)`,
+                  left: getHoveredAction()?.position.left,
+                  transform: "translate(-50%, 0)"
+                }}
+              >
+                <div className="bg-pink-500 text-white p-3 rounded-lg max-w-xs shadow-xl">
                   <p className="text-xs leading-relaxed">
                     {getHoveredAction()?.description}
                   </p>
                   {/* Tooltip arrow */}
-                  <div className="absolute top-full left-6 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent border-t-pink-500"></div>
+                  <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-6 border-r-6 border-t-6 border-l-transparent border-r-transparent border-t-pink-500"></div>
                 </div>
               </div>
             )}

--- a/client/pages/Plans.tsx
+++ b/client/pages/Plans.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Check } from 'lucide-react';
+import React from "react";
+import { Check } from "lucide-react";
 
 const Plans = () => {
   return (
@@ -11,13 +11,15 @@ const Plans = () => {
             {/* Logo */}
             <div className="flex items-center">
               <div className="w-8 h-8 mr-3">
-                <img 
+                <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
                   alt="TaleTree Logo"
                   className="w-full h-full object-contain"
                 />
               </div>
-              <span className="text-xl font-semibold text-gray-900">taleTree</span>
+              <span className="text-xl font-semibold text-gray-900">
+                taleTree
+              </span>
             </div>
 
             {/* Login Button */}
@@ -34,7 +36,9 @@ const Plans = () => {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Page Title */}
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">TaleTree Pricing</h1>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">
+            TaleTree Pricing
+          </h1>
           <p className="text-lg text-gray-600 max-w-2xl mx-auto">
             Choose the plan that fits your family or organization.
           </p>
@@ -45,8 +49,12 @@ const Plans = () => {
           {/* Emeralites Plan */}
           <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8 relative">
             <div className="mb-6">
-              <h3 className="text-xl font-semibold text-cyan-600 mb-2">Emeralites</h3>
-              <p className="text-gray-600 text-sm mb-4">For curious kids just starting out</p>
+              <h3 className="text-xl font-semibold text-cyan-600 mb-2">
+                Emeralites
+              </h3>
+              <p className="text-gray-600 text-sm mb-4">
+                For curious kids just starting out
+              </p>
               <div className="mb-6">
                 <span className="text-3xl font-bold text-gray-900">$0</span>
                 <span className="text-gray-600 ml-2">/ month</span>
@@ -56,19 +64,27 @@ const Plans = () => {
             <ul className="space-y-3 mb-8">
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Up to 20 TaleTree creations</span>
+                <span className="text-gray-700 text-sm">
+                  Up to 20 TaleTree creations
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">AI powered emotional reflections</span>
+                <span className="text-gray-700 text-sm">
+                  AI powered emotional reflections
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Guardian account verification required</span>
+                <span className="text-gray-700 text-sm">
+                  Guardian account verification required
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Limited access to the TaleTree Method</span>
+                <span className="text-gray-700 text-sm">
+                  Limited access to the TaleTree Method
+                </span>
               </li>
             </ul>
 
@@ -80,8 +96,12 @@ const Plans = () => {
           {/* Seedlings Plan */}
           <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8 relative">
             <div className="mb-6">
-              <h3 className="text-xl font-semibold text-green-600 mb-2">Seedlings</h3>
-              <p className="text-gray-600 text-sm mb-4">For families ready to grow together</p>
+              <h3 className="text-xl font-semibold text-green-600 mb-2">
+                Seedlings
+              </h3>
+              <p className="text-gray-600 text-sm mb-4">
+                For families ready to grow together
+              </p>
               <div className="mb-6">
                 <span className="text-3xl font-bold text-gray-900">$10</span>
                 <span className="text-gray-600 ml-2">/ month per child</span>
@@ -91,23 +111,33 @@ const Plans = () => {
             <ul className="space-y-3 mb-8">
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Unlimited TaleTree creations</span>
+                <span className="text-gray-700 text-sm">
+                  Unlimited TaleTree creations
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Full access to AI companions</span>
+                <span className="text-gray-700 text-sm">
+                  Full access to AI companions
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Weekly guardian insights & reports</span>
+                <span className="text-gray-700 text-sm">
+                  Weekly guardian insights & reports
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">20-Minute Promise tools</span>
+                <span className="text-gray-700 text-sm">
+                  20-Minute Promise tools
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Daily emotional check-ins</span>
+                <span className="text-gray-700 text-sm">
+                  Daily emotional check-ins
+                </span>
               </li>
             </ul>
 
@@ -119,33 +149,49 @@ const Plans = () => {
           {/* Villagers Plan */}
           <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8 relative">
             <div className="mb-6">
-              <h3 className="text-xl font-semibold text-purple-600 mb-2">Villagers</h3>
-              <p className="text-gray-600 text-sm mb-4">For schools, churches, and camps</p>
+              <h3 className="text-xl font-semibold text-purple-600 mb-2">
+                Villagers
+              </h3>
+              <p className="text-gray-600 text-sm mb-4">
+                For schools, churches, and camps
+              </p>
               <div className="mb-6">
-                <span className="text-3xl font-bold text-gray-900">Contact Sales</span>
+                <span className="text-3xl font-bold text-gray-900">
+                  Contact Sales
+                </span>
               </div>
             </div>
 
             <ul className="space-y-3 mb-8">
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Set up Camps & Tribes</span>
+                <span className="text-gray-700 text-sm">
+                  Set up Camps & Tribes
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Manage groups & progress</span>
+                <span className="text-gray-700 text-sm">
+                  Manage groups & progress
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">All Seedlings features included</span>
+                <span className="text-gray-700 text-sm">
+                  All Seedlings features included
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Institution-wide guardian engagement</span>
+                <span className="text-gray-700 text-sm">
+                  Institution-wide guardian engagement
+                </span>
               </li>
               <li className="flex items-start gap-3">
                 <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-                <span className="text-gray-700 text-sm">Custom challenge creation</span>
+                <span className="text-gray-700 text-sm">
+                  Custom challenge creation
+                </span>
               </li>
             </ul>
 
@@ -172,9 +218,21 @@ const Plans = () => {
             <div className="md:col-span-1">
               <h4 className="font-semibold mb-4">Company</h4>
               <ul className="space-y-2 text-sm text-indigo-200">
-                <li><a href="#" className="hover:text-white">Our story</a></li>
-                <li><a href="#" className="hover:text-white">TaleTree Friends</a></li>
-                <li><a href="#" className="hover:text-white">TaleTree Pledge</a></li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Our story
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    TaleTree Friends
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    TaleTree Pledge
+                  </a>
+                </li>
               </ul>
             </div>
 
@@ -182,10 +240,26 @@ const Plans = () => {
             <div className="md:col-span-1">
               <h4 className="font-semibold mb-4">Support</h4>
               <ul className="space-y-2 text-sm text-indigo-200">
-                <li><a href="#" className="hover:text-white">Terms of Service</a></li>
-                <li><a href="#" className="hover:text-white">Privacy Policy</a></li>
-                <li><a href="#" className="hover:text-white">End User License Agreement</a></li>
-                <li><a href="#" className="hover:text-white">Email Us</a></li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Terms of Service
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Privacy Policy
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    End User License Agreement
+                  </a>
+                </li>
+                <li>
+                  <a href="#" className="hover:text-white">
+                    Email Us
+                  </a>
+                </li>
               </ul>
             </div>
 
@@ -211,8 +285,12 @@ const Plans = () => {
 
           {/* Bottom Footer */}
           <div className="border-t border-indigo-800 mt-8 pt-8 flex flex-col md:flex-row justify-between items-center">
-            <p className="text-indigo-200 text-sm">2025 TaleTree Inc. All rights reserved</p>
-            <p className="text-indigo-200 text-sm">Email: contact@taletree.com</p>
+            <p className="text-indigo-200 text-sm">
+              2025 TaleTree Inc. All rights reserved
+            </p>
+            <p className="text-indigo-200 text-sm">
+              Email: contact@taletree.com
+            </p>
           </div>
         </div>
       </footer>

--- a/client/pages/Plans.tsx
+++ b/client/pages/Plans.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { Check } from 'lucide-react';
+
+const Plans = () => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            {/* Logo */}
+            <div className="flex items-center">
+              <div className="w-8 h-8 mr-3">
+                <img 
+                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
+                  alt="TaleTree Logo"
+                  className="w-full h-full object-contain"
+                />
+              </div>
+              <span className="text-xl font-semibold text-gray-900">taleTree</span>
+            </div>
+
+            {/* Login Button */}
+            <div className="flex items-center gap-4">
+              <button className="border border-gray-300 text-gray-700 px-4 py-2 rounded-full font-medium text-sm hover:bg-gray-50 transition-colors duration-200 flex items-center gap-2">
+                Login
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Page Title */}
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">TaleTree Pricing</h1>
+          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+            Choose the plan that fits your family or organization.
+          </p>
+        </div>
+
+        {/* Pricing Cards */}
+        <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+          {/* Emeralites Plan */}
+          <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8 relative">
+            <div className="mb-6">
+              <h3 className="text-xl font-semibold text-cyan-600 mb-2">Emeralites</h3>
+              <p className="text-gray-600 text-sm mb-4">For curious kids just starting out</p>
+              <div className="mb-6">
+                <span className="text-3xl font-bold text-gray-900">$0</span>
+                <span className="text-gray-600 ml-2">/ month</span>
+              </div>
+            </div>
+
+            <ul className="space-y-3 mb-8">
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Up to 20 TaleTree creations</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">AI powered emotional reflections</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Guardian account verification required</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Limited access to the TaleTree Method</span>
+              </li>
+            </ul>
+
+            <div className="bg-gray-100 text-gray-500 py-3 px-6 rounded-full text-center font-medium">
+              You current plan
+            </div>
+          </div>
+
+          {/* Seedlings Plan */}
+          <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8 relative">
+            <div className="mb-6">
+              <h3 className="text-xl font-semibold text-green-600 mb-2">Seedlings</h3>
+              <p className="text-gray-600 text-sm mb-4">For families ready to grow together</p>
+              <div className="mb-6">
+                <span className="text-3xl font-bold text-gray-900">$10</span>
+                <span className="text-gray-600 ml-2">/ month per child</span>
+              </div>
+            </div>
+
+            <ul className="space-y-3 mb-8">
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Unlimited TaleTree creations</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Full access to AI companions</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Weekly guardian insights & reports</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">20-Minute Promise tools</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Daily emotional check-ins</span>
+              </li>
+            </ul>
+
+            <button className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-6 rounded-full transition-colors duration-200">
+              Get Seedlings
+            </button>
+          </div>
+
+          {/* Villagers Plan */}
+          <div className="bg-white rounded-2xl shadow-lg border border-gray-200 p-8 relative">
+            <div className="mb-6">
+              <h3 className="text-xl font-semibold text-purple-600 mb-2">Villagers</h3>
+              <p className="text-gray-600 text-sm mb-4">For schools, churches, and camps</p>
+              <div className="mb-6">
+                <span className="text-3xl font-bold text-gray-900">Contact Sales</span>
+              </div>
+            </div>
+
+            <ul className="space-y-3 mb-8">
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Set up Camps & Tribes</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Manage groups & progress</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">All Seedlings features included</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Institution-wide guardian engagement</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span className="text-gray-700 text-sm">Custom challenge creation</span>
+              </li>
+            </ul>
+
+            <button className="w-full bg-purple-600 hover:bg-purple-700 text-white font-medium py-3 px-6 rounded-full transition-colors duration-200">
+              Get Villagers
+            </button>
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-indigo-900 text-white mt-20">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+            {/* Company Info */}
+            <div className="md:col-span-1">
+              <h3 className="text-xl font-semibold mb-4">TaleTree Inc.</h3>
+              <p className="text-indigo-200 text-sm">
+                470 Ramona St. Palo Alto, CA 94301, USA
+              </p>
+            </div>
+
+            {/* Company Links */}
+            <div className="md:col-span-1">
+              <h4 className="font-semibold mb-4">Company</h4>
+              <ul className="space-y-2 text-sm text-indigo-200">
+                <li><a href="#" className="hover:text-white">Our story</a></li>
+                <li><a href="#" className="hover:text-white">TaleTree Friends</a></li>
+                <li><a href="#" className="hover:text-white">TaleTree Pledge</a></li>
+              </ul>
+            </div>
+
+            {/* Support Links */}
+            <div className="md:col-span-1">
+              <h4 className="font-semibold mb-4">Support</h4>
+              <ul className="space-y-2 text-sm text-indigo-200">
+                <li><a href="#" className="hover:text-white">Terms of Service</a></li>
+                <li><a href="#" className="hover:text-white">Privacy Policy</a></li>
+                <li><a href="#" className="hover:text-white">End User License Agreement</a></li>
+                <li><a href="#" className="hover:text-white">Email Us</a></li>
+              </ul>
+            </div>
+
+            {/* Follow Us */}
+            <div className="md:col-span-1">
+              <h4 className="font-semibold mb-4">Follow us</h4>
+              <div className="flex space-x-3">
+                <div className="w-8 h-8 bg-indigo-700 rounded-full flex items-center justify-center">
+                  <span className="text-xs">f</span>
+                </div>
+                <div className="w-8 h-8 bg-indigo-700 rounded-full flex items-center justify-center">
+                  <span className="text-xs">t</span>
+                </div>
+                <div className="w-8 h-8 bg-indigo-700 rounded-full flex items-center justify-center">
+                  <span className="text-xs">i</span>
+                </div>
+                <div className="w-8 h-8 bg-indigo-700 rounded-full flex items-center justify-center">
+                  <span className="text-xs">l</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Bottom Footer */}
+          <div className="border-t border-indigo-800 mt-8 pt-8 flex flex-col md:flex-row justify-between items-center">
+            <p className="text-indigo-200 text-sm">2025 TaleTree Inc. All rights reserved</p>
+            <p className="text-indigo-200 text-sm">Email: contact@taletree.com</p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default Plans;

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import DecorativeStars from "@/components/signup/DecorativeStars";
 import HeroSection from "@/components/signup/HeroSection";
 import PlansStrip from "@/components/signup/PlansStrip";
@@ -8,8 +9,14 @@ import ParentsSection from "@/components/signup/ParentsSection";
 import EducatorsSection from "@/components/signup/EducatorsSection";
 import ExpertsSection from "@/components/signup/ExpertsSection";
 import SignupFooter from "@/components/signup/SignupFooter";
+import Plans from "./Plans";
 
 const Signup = () => {
+  const [showPlans, setShowPlans] = useState(false);
+
+  if (showPlans) {
+    return <Plans />;
+  }
   return (
     <div className="relative">
       {/* Hero Section - Full Viewport */}

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -1,4 +1,3 @@
-import SignupNavigation from "@/components/signup/SignupNavigation";
 import DecorativeStars from "@/components/signup/DecorativeStars";
 import HeroSection from "@/components/signup/HeroSection";
 import CreativitySection from "@/components/signup/CreativitySection";
@@ -11,10 +10,7 @@ import SignupFooter from "@/components/signup/SignupFooter";
 
 const Signup = () => {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-indigo-800 overflow-x-hidden">
-      {/* Navigation Header */}
-      <SignupNavigation />
-
+    <div className="min-h-screen overflow-x-hidden">
       {/* Stars/Decorative Elements */}
       <DecorativeStars />
 

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -1,367 +1,38 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Card, CardContent } from "@/components/ui/card";
+import SignupNavigation from "@/components/signup/SignupNavigation";
+import DecorativeStars from "@/components/signup/DecorativeStars";
+import HeroSection from "@/components/signup/HeroSection";
+import CreativitySection from "@/components/signup/CreativitySection";
+import IntroducingSection from "@/components/signup/IntroducingSection";
+import LatestNewsSection from "@/components/signup/LatestNewsSection";
+import ParentsSection from "@/components/signup/ParentsSection";
+import EducatorsSection from "@/components/signup/EducatorsSection";
+import ExpertsSection from "@/components/signup/ExpertsSection";
+import SignupFooter from "@/components/signup/SignupFooter";
 
 const Signup = () => {
-  const [searchQuery, setSearchQuery] = useState("");
-
   return (
     <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-indigo-800 overflow-x-hidden">
       {/* Navigation Header */}
-      <nav className="flex items-center justify-between p-4 relative z-10">
-        <div className="flex items-center space-x-2">
-          <div className="w-10 h-10 bg-cyan-400 rounded-full flex items-center justify-center">
-            <div className="w-6 h-6 bg-white rounded-full"></div>
-          </div>
-          <div>
-            <h1 className="text-white text-xl font-bold">taleTree</h1>
-            <p className="text-cyan-300 text-xs">
-              A New Kind of Curriculum for a New Kind of World
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center space-x-6">
-          <button className="text-white hover:text-cyan-300 transition-colors">
-            Features
-          </button>
-          <button className="text-white hover:text-cyan-300 transition-colors">
-            Pricing
-          </button>
-          <button className="text-white hover:text-cyan-300 transition-colors">
-            About
-          </button>
-          <Button className="bg-cyan-400 hover:bg-cyan-500 text-black rounded-full px-6">
-            Get Started
-          </Button>
-        </div>
-      </nav>
+      <SignupNavigation />
 
       {/* Stars/Decorative Elements */}
-      <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute top-20 left-10 w-2 h-2 bg-pink-400 rounded-full animate-pulse"></div>
-        <div className="absolute top-32 right-20 w-1 h-1 bg-yellow-400 rounded-full animate-pulse"></div>
-        <div className="absolute top-16 right-32 w-3 h-3 bg-orange-400 rounded-full animate-pulse"></div>
-        <div className="absolute top-40 left-32 w-2 h-2 bg-purple-400 rounded-full animate-pulse"></div>
-        <div className="absolute top-24 left-1/3 w-1 h-1 bg-cyan-400 rounded-full animate-pulse"></div>
-        <div className="absolute top-28 right-1/4 w-2 h-2 bg-pink-300 rounded-full animate-pulse"></div>
-      </div>
+      <DecorativeStars />
 
       {/* Main Hero Section */}
-      <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
-        {/* Background Landscape */}
-        <div className="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-green-400 via-yellow-300 to-transparent rounded-t-full transform scale-150 origin-bottom"></div>
-
-        {/* Mountains/Hills */}
-        <div className="absolute bottom-16 left-0 right-0 flex justify-center space-x-4">
-          <div className="w-32 h-24 bg-green-500 rounded-t-full"></div>
-          <div className="w-40 h-32 bg-green-600 rounded-t-full"></div>
-          <div className="w-28 h-20 bg-green-400 rounded-t-full"></div>
-        </div>
-
-        {/* Character - Green Bunny */}
-        <div className="relative z-10 mb-8 animate-gentle-float">
-          <div className="w-32 h-40 relative">
-            {/* Bunny Body */}
-            <div className="w-20 h-24 bg-green-400 rounded-full mx-auto"></div>
-            {/* Bunny Head */}
-            <div className="w-16 h-16 bg-green-400 rounded-full mx-auto -mt-4 relative">
-              {/* Ears */}
-              <div className="absolute -top-6 left-2 w-3 h-8 bg-green-400 rounded-full rotate-12"></div>
-              <div className="absolute -top-6 right-2 w-3 h-8 bg-green-400 rounded-full -rotate-12"></div>
-              {/* Eyes */}
-              <div className="absolute top-4 left-3 w-2 h-2 bg-black rounded-full"></div>
-              <div className="absolute top-4 right-3 w-2 h-2 bg-black rounded-full"></div>
-              {/* Mouth */}
-              <div className="absolute top-7 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-black rounded-full"></div>
-            </div>
-            {/* Arms */}
-            <div className="absolute top-6 -left-3 w-6 h-12 bg-green-400 rounded-full rotate-12"></div>
-            <div className="absolute top-6 -right-3 w-6 h-12 bg-green-400 rounded-full -rotate-12"></div>
-          </div>
-        </div>
-
-        {/* Speech Bubble */}
-        <div className="relative z-10 mb-8">
-          <div className="bg-cyan-400 rounded-2xl p-4 max-w-sm text-center relative">
-            <p className="text-black font-medium">
-              It's time to start. Share the beautiful, magical stories and
-              stories.
-            </p>
-            {/* Bubble tail */}
-            <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 w-4 h-4 bg-cyan-400 rotate-45"></div>
-          </div>
-        </div>
-
-        {/* Search Input Section */}
-        <div className="relative z-10 w-full max-w-md mb-4">
-          <div className="relative">
-            <Input
-              type="text"
-              placeholder="Enter anything..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full h-14 pl-4 pr-16 rounded-full border-2 border-orange-300 bg-white text-black placeholder-gray-500 text-lg"
-            />
-            <Button className="absolute right-2 top-2 h-10 w-10 bg-orange-400 hover:bg-orange-500 rounded-full p-0">
-              <svg
-                className="w-5 h-5 text-white"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-            </Button>
-          </div>
-        </div>
-
-        {/* Support Text */}
-        <p className="relative z-10 text-white/80 text-sm">
-          <span className="font-semibold">ADULTS</span> can get Support
-        </p>
-      </div>
+      <HeroSection />
 
       {/* Content Sections */}
       <div className="relative z-10 bg-white mt-8">
-        {/* Creativity Section */}
-        <div className="px-8 py-8 text-center">
-          <p className="text-gray-700 mb-2">
-            <span className="font-semibold">
-              Creativity and kindness matter more than score
-            </span>{" "}
-            in the age of
-            <span className="inline-flex items-center mx-1 px-2 py-1 bg-purple-100 text-purple-800 rounded text-sm">
-              AI
-            </span>
-          </p>
-          <p className="text-gray-600">
-            TaleTree helps your child grow both — and get rewarded for it.
-          </p>
-        </div>
-
-        {/* Introducing TaleTree Section */}
-        <div className="px-8 py-8">
-          <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-bold text-gray-900">
-              Introducing TaleTree
-            </h2>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {/* Left - Character illustration */}
-            <div className="bg-gradient-to-br from-orange-400 to-red-500 rounded-xl p-6 h-64 relative overflow-hidden">
-              <div className="absolute bottom-4 left-4">
-                <div className="w-16 h-20 bg-orange-600 rounded-full relative">
-                  {/* Simple character representation */}
-                  <div className="absolute top-2 left-3 w-2 h-2 bg-white rounded-full"></div>
-                  <div className="absolute top-2 right-3 w-2 h-2 bg-white rounded-full"></div>
-                  <div className="absolute top-6 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-white rounded-full"></div>
-                </div>
-              </div>
-              <div className="absolute inset-0 bg-gradient-to-t from-green-400/20 to-transparent rounded-xl"></div>
-            </div>
-
-            {/* Right - Family photo placeholder */}
-            <div className="bg-gray-200 rounded-xl h-64 flex items-center justify-center">
-              <div className="text-center">
-                <div className="w-20 h-20 bg-gray-300 rounded-full mx-auto mb-4"></div>
-                <p className="text-gray-600 text-sm">Families that talk</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Latest News Grid */}
-        <div className="px-8 py-8">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-xl font-semibold text-gray-900">Latest news</h3>
-            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
-              View all
-            </button>
-          </div>
-
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <Card key={i} className="bg-gray-100 border-0">
-                <CardContent className="p-3">
-                  <div className="w-full h-20 bg-gray-200 rounded mb-2"></div>
-                  <p className="text-xs text-gray-600 mb-1">
-                    News headline here
-                  </p>
-                  <p className="text-xs text-gray-500">Jan 24, 2024</p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-
-        {/* Parents Section */}
-        <div className="px-8 py-8">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-xl font-semibold text-gray-900">Parents</h3>
-            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
-              View all
-            </button>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Card key={i} className="bg-gray-100 border-0">
-                <CardContent className="p-4">
-                  <div className="w-full h-32 bg-gray-200 rounded mb-3"></div>
-                  <p className="text-sm text-gray-700 mb-2">
-                    Parent story title
-                  </p>
-                  <p className="text-xs text-gray-500">
-                    Story description here
-                  </p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-
-        {/* TaleTree for Educators */}
-        <div className="px-8 py-8">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-xl font-semibold text-gray-900">
-              TaleTree for Educators
-            </h3>
-            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
-              View all
-            </button>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <Card className="bg-gray-100 border-0">
-              <CardContent className="p-6">
-                <div className="w-full h-40 bg-gray-200 rounded mb-4"></div>
-                <p className="text-sm text-gray-700 mb-2">
-                  Learn about what we offer
-                </p>
-                <p className="text-xs text-gray-500">Jan 24, 2024</p>
-              </CardContent>
-            </Card>
-
-            <Card className="bg-gray-100 border-0">
-              <CardContent className="p-6">
-                <div className="w-full h-40 bg-gray-200 rounded mb-4"></div>
-                <p className="text-sm text-gray-700 mb-2">
-                  The TaleTree Method
-                </p>
-                <p className="text-xs text-gray-500">Jan 24, 2024</p>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-
-        {/* Experts and Brands */}
-        <div className="px-8 py-8">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-xl font-semibold text-gray-900">
-              Experts and Brands
-            </h3>
-            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
-              View all
-            </button>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Card key={i} className="bg-gray-100 border-0">
-                <CardContent className="p-6">
-                  <div className="w-full h-32 bg-gray-200 rounded mb-4"></div>
-                  <p className="text-sm text-gray-700 mb-2">
-                    Expert opinion piece
-                  </p>
-                  <p className="text-xs text-gray-500">Jan 24, 2024</p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
+        <CreativitySection />
+        <IntroducingSection />
+        <LatestNewsSection />
+        <ParentsSection />
+        <EducatorsSection />
+        <ExpertsSection />
       </div>
 
       {/* Footer */}
-      <footer className="bg-indigo-900 text-white py-12 px-8">
-        <div className="max-w-6xl mx-auto">
-          <div className="flex flex-col md:flex-row justify-between">
-            <div className="mb-8 md:mb-0">
-              <h4 className="text-xl font-bold mb-4">TaleTree Inc.</h4>
-              <p className="text-gray-300 text-sm">
-                149 Barrow St, Floor 2nd, New York, NY 10014, USA
-              </p>
-            </div>
-
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-8">
-              <div>
-                <h5 className="font-semibold mb-3">Company</h5>
-                <ul className="space-y-2 text-sm text-gray-300">
-                  <li>
-                    <a href="#" className="hover:text-white">
-                      Our Story
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" className="hover:text-white">
-                      Careers
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" className="hover:text-white">
-                      Contact
-                    </a>
-                  </li>
-                </ul>
-              </div>
-
-              <div>
-                <h5 className="font-semibold mb-3">Support</h5>
-                <ul className="space-y-2 text-sm text-gray-300">
-                  <li>
-                    <a href="#" className="hover:text-white">
-                      Getting Started
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" className="hover:text-white">
-                      Help Center
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#" className="hover:text-white">
-                      Server Status
-                    </a>
-                  </li>
-                </ul>
-              </div>
-
-              <div>
-                <h5 className="font-semibold mb-3">Follow us</h5>
-                <div className="flex space-x-3">
-                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
-                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
-                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
-                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="border-t border-gray-700 mt-8 pt-6 text-center text-sm text-gray-400">
-            <p>
-              2024, TaleTree Inc. All rights reserved. | Email:
-              contact@taletree.com
-            </p>
-          </div>
-        </div>
-      </footer>
+      <SignupFooter />
     </div>
   );
 };

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -21,6 +21,9 @@ const Signup = () => {
         <HeroSection />
       </div>
 
+      {/* Plans Strip - Between Hero and Content */}
+      <PlansStrip />
+
       {/* Content Sections - Below Hero */}
       <div className="relative z-10 bg-white">
         <CreativitySection />

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -1,5 +1,6 @@
 import DecorativeStars from "@/components/signup/DecorativeStars";
 import HeroSection from "@/components/signup/HeroSection";
+import PlansStrip from "@/components/signup/PlansStrip";
 import CreativitySection from "@/components/signup/CreativitySection";
 import IntroducingSection from "@/components/signup/IntroducingSection";
 import LatestNewsSection from "@/components/signup/LatestNewsSection";

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -10,15 +10,18 @@ import SignupFooter from "@/components/signup/SignupFooter";
 
 const Signup = () => {
   return (
-    <div className="min-h-screen overflow-x-hidden">
-      {/* Stars/Decorative Elements */}
-      <DecorativeStars />
+    <div className="relative">
+      {/* Hero Section - Full Viewport */}
+      <div className="relative z-0">
+        {/* Stars/Decorative Elements */}
+        <DecorativeStars />
 
-      {/* Main Hero Section */}
-      <HeroSection />
+        {/* Main Hero Section */}
+        <HeroSection />
+      </div>
 
-      {/* Content Sections */}
-      <div className="relative z-10 bg-white mt-8">
+      {/* Content Sections - Below Hero */}
+      <div className="relative z-10 bg-white">
         <CreativitySection />
         <IntroducingSection />
         <LatestNewsSection />
@@ -28,7 +31,9 @@ const Signup = () => {
       </div>
 
       {/* Footer */}
-      <SignupFooter />
+      <div className="relative z-10">
+        <SignupFooter />
+      </div>
     </div>
   );
 };

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -1,0 +1,369 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+
+const Signup = () => {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-indigo-900 via-purple-900 to-indigo-800 overflow-x-hidden">
+      {/* Navigation Header */}
+      <nav className="flex items-center justify-between p-4 relative z-10">
+        <div className="flex items-center space-x-2">
+          <div className="w-10 h-10 bg-cyan-400 rounded-full flex items-center justify-center">
+            <div className="w-6 h-6 bg-white rounded-full"></div>
+          </div>
+          <div>
+            <h1 className="text-white text-xl font-bold">taleTree</h1>
+            <p className="text-cyan-300 text-xs">
+              A New Kind of Curriculum for a New Kind of World
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center space-x-6">
+          <button className="text-white hover:text-cyan-300 transition-colors">
+            Features
+          </button>
+          <button className="text-white hover:text-cyan-300 transition-colors">
+            Pricing
+          </button>
+          <button className="text-white hover:text-cyan-300 transition-colors">
+            About
+          </button>
+          <Button className="bg-cyan-400 hover:bg-cyan-500 text-black rounded-full px-6">
+            Get Started
+          </Button>
+        </div>
+      </nav>
+
+      {/* Stars/Decorative Elements */}
+      <div className="absolute inset-0 overflow-hidden">
+        <div className="absolute top-20 left-10 w-2 h-2 bg-pink-400 rounded-full animate-pulse"></div>
+        <div className="absolute top-32 right-20 w-1 h-1 bg-yellow-400 rounded-full animate-pulse"></div>
+        <div className="absolute top-16 right-32 w-3 h-3 bg-orange-400 rounded-full animate-pulse"></div>
+        <div className="absolute top-40 left-32 w-2 h-2 bg-purple-400 rounded-full animate-pulse"></div>
+        <div className="absolute top-24 left-1/3 w-1 h-1 bg-cyan-400 rounded-full animate-pulse"></div>
+        <div className="absolute top-28 right-1/4 w-2 h-2 bg-pink-300 rounded-full animate-pulse"></div>
+      </div>
+
+      {/* Main Hero Section */}
+      <div className="relative flex flex-col items-center justify-center min-h-[70vh] px-4">
+        {/* Background Landscape */}
+        <div className="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-green-400 via-yellow-300 to-transparent rounded-t-full transform scale-150 origin-bottom"></div>
+
+        {/* Mountains/Hills */}
+        <div className="absolute bottom-16 left-0 right-0 flex justify-center space-x-4">
+          <div className="w-32 h-24 bg-green-500 rounded-t-full"></div>
+          <div className="w-40 h-32 bg-green-600 rounded-t-full"></div>
+          <div className="w-28 h-20 bg-green-400 rounded-t-full"></div>
+        </div>
+
+        {/* Character - Green Bunny */}
+        <div className="relative z-10 mb-8 animate-gentle-float">
+          <div className="w-32 h-40 relative">
+            {/* Bunny Body */}
+            <div className="w-20 h-24 bg-green-400 rounded-full mx-auto"></div>
+            {/* Bunny Head */}
+            <div className="w-16 h-16 bg-green-400 rounded-full mx-auto -mt-4 relative">
+              {/* Ears */}
+              <div className="absolute -top-6 left-2 w-3 h-8 bg-green-400 rounded-full rotate-12"></div>
+              <div className="absolute -top-6 right-2 w-3 h-8 bg-green-400 rounded-full -rotate-12"></div>
+              {/* Eyes */}
+              <div className="absolute top-4 left-3 w-2 h-2 bg-black rounded-full"></div>
+              <div className="absolute top-4 right-3 w-2 h-2 bg-black rounded-full"></div>
+              {/* Mouth */}
+              <div className="absolute top-7 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-black rounded-full"></div>
+            </div>
+            {/* Arms */}
+            <div className="absolute top-6 -left-3 w-6 h-12 bg-green-400 rounded-full rotate-12"></div>
+            <div className="absolute top-6 -right-3 w-6 h-12 bg-green-400 rounded-full -rotate-12"></div>
+          </div>
+        </div>
+
+        {/* Speech Bubble */}
+        <div className="relative z-10 mb-8">
+          <div className="bg-cyan-400 rounded-2xl p-4 max-w-sm text-center relative">
+            <p className="text-black font-medium">
+              It's time to start. Share the beautiful, magical stories and
+              stories.
+            </p>
+            {/* Bubble tail */}
+            <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 w-4 h-4 bg-cyan-400 rotate-45"></div>
+          </div>
+        </div>
+
+        {/* Search Input Section */}
+        <div className="relative z-10 w-full max-w-md mb-4">
+          <div className="relative">
+            <Input
+              type="text"
+              placeholder="Enter anything..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full h-14 pl-4 pr-16 rounded-full border-2 border-orange-300 bg-white text-black placeholder-gray-500 text-lg"
+            />
+            <Button className="absolute right-2 top-2 h-10 w-10 bg-orange-400 hover:bg-orange-500 rounded-full p-0">
+              <svg
+                className="w-5 h-5 text-white"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+            </Button>
+          </div>
+        </div>
+
+        {/* Support Text */}
+        <p className="relative z-10 text-white/80 text-sm">
+          <span className="font-semibold">ADULTS</span> can get Support
+        </p>
+      </div>
+
+      {/* Content Sections */}
+      <div className="relative z-10 bg-white mt-8">
+        {/* Creativity Section */}
+        <div className="px-8 py-8 text-center">
+          <p className="text-gray-700 mb-2">
+            <span className="font-semibold">
+              Creativity and kindness matter more than score
+            </span>{" "}
+            in the age of
+            <span className="inline-flex items-center mx-1 px-2 py-1 bg-purple-100 text-purple-800 rounded text-sm">
+              AI
+            </span>
+          </p>
+          <p className="text-gray-600">
+            TaleTree helps your child grow both — and get rewarded for it.
+          </p>
+        </div>
+
+        {/* Introducing TaleTree Section */}
+        <div className="px-8 py-8">
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-2xl font-bold text-gray-900">
+              Introducing TaleTree
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Left - Character illustration */}
+            <div className="bg-gradient-to-br from-orange-400 to-red-500 rounded-xl p-6 h-64 relative overflow-hidden">
+              <div className="absolute bottom-4 left-4">
+                <div className="w-16 h-20 bg-orange-600 rounded-full relative">
+                  {/* Simple character representation */}
+                  <div className="absolute top-2 left-3 w-2 h-2 bg-white rounded-full"></div>
+                  <div className="absolute top-2 right-3 w-2 h-2 bg-white rounded-full"></div>
+                  <div className="absolute top-6 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-white rounded-full"></div>
+                </div>
+              </div>
+              <div className="absolute inset-0 bg-gradient-to-t from-green-400/20 to-transparent rounded-xl"></div>
+            </div>
+
+            {/* Right - Family photo placeholder */}
+            <div className="bg-gray-200 rounded-xl h-64 flex items-center justify-center">
+              <div className="text-center">
+                <div className="w-20 h-20 bg-gray-300 rounded-full mx-auto mb-4"></div>
+                <p className="text-gray-600 text-sm">Families that talk</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Latest News Grid */}
+        <div className="px-8 py-8">
+          <div className="flex items-center justify-between mb-6">
+            <h3 className="text-xl font-semibold text-gray-900">Latest news</h3>
+            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+              View all
+            </button>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Card key={i} className="bg-gray-100 border-0">
+                <CardContent className="p-3">
+                  <div className="w-full h-20 bg-gray-200 rounded mb-2"></div>
+                  <p className="text-xs text-gray-600 mb-1">
+                    News headline here
+                  </p>
+                  <p className="text-xs text-gray-500">Jan 24, 2024</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+
+        {/* Parents Section */}
+        <div className="px-8 py-8">
+          <div className="flex items-center justify-between mb-6">
+            <h3 className="text-xl font-semibold text-gray-900">Parents</h3>
+            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+              View all
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Card key={i} className="bg-gray-100 border-0">
+                <CardContent className="p-4">
+                  <div className="w-full h-32 bg-gray-200 rounded mb-3"></div>
+                  <p className="text-sm text-gray-700 mb-2">
+                    Parent story title
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Story description here
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+
+        {/* TaleTree for Educators */}
+        <div className="px-8 py-8">
+          <div className="flex items-center justify-between mb-6">
+            <h3 className="text-xl font-semibold text-gray-900">
+              TaleTree for Educators
+            </h3>
+            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+              View all
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <Card className="bg-gray-100 border-0">
+              <CardContent className="p-6">
+                <div className="w-full h-40 bg-gray-200 rounded mb-4"></div>
+                <p className="text-sm text-gray-700 mb-2">
+                  Learn about what we offer
+                </p>
+                <p className="text-xs text-gray-500">Jan 24, 2024</p>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-gray-100 border-0">
+              <CardContent className="p-6">
+                <div className="w-full h-40 bg-gray-200 rounded mb-4"></div>
+                <p className="text-sm text-gray-700 mb-2">
+                  The TaleTree Method
+                </p>
+                <p className="text-xs text-gray-500">Jan 24, 2024</p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        {/* Experts and Brands */}
+        <div className="px-8 py-8">
+          <div className="flex items-center justify-between mb-6">
+            <h3 className="text-xl font-semibold text-gray-900">
+              Experts and Brands
+            </h3>
+            <button className="text-purple-600 hover:text-purple-700 text-sm font-medium">
+              View all
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Card key={i} className="bg-gray-100 border-0">
+                <CardContent className="p-6">
+                  <div className="w-full h-32 bg-gray-200 rounded mb-4"></div>
+                  <p className="text-sm text-gray-700 mb-2">
+                    Expert opinion piece
+                  </p>
+                  <p className="text-xs text-gray-500">Jan 24, 2024</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <footer className="bg-indigo-900 text-white py-12 px-8">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex flex-col md:flex-row justify-between">
+            <div className="mb-8 md:mb-0">
+              <h4 className="text-xl font-bold mb-4">TaleTree Inc.</h4>
+              <p className="text-gray-300 text-sm">
+                149 Barrow St, Floor 2nd, New York, NY 10014, USA
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-8">
+              <div>
+                <h5 className="font-semibold mb-3">Company</h5>
+                <ul className="space-y-2 text-sm text-gray-300">
+                  <li>
+                    <a href="#" className="hover:text-white">
+                      Our Story
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:text-white">
+                      Careers
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:text-white">
+                      Contact
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
+              <div>
+                <h5 className="font-semibold mb-3">Support</h5>
+                <ul className="space-y-2 text-sm text-gray-300">
+                  <li>
+                    <a href="#" className="hover:text-white">
+                      Getting Started
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:text-white">
+                      Help Center
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:text-white">
+                      Server Status
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
+              <div>
+                <h5 className="font-semibold mb-3">Follow us</h5>
+                <div className="flex space-x-3">
+                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+                  <div className="w-8 h-8 bg-gray-600 rounded-full"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-700 mt-8 pt-6 text-center text-sm text-gray-400">
+            <p>
+              2024, TaleTree Inc. All rights reserved. | Email:
+              contact@taletree.com
+            </p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default Signup;

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -31,7 +31,7 @@ const Signup = () => {
       {/* Content Sections - Below Hero */}
       <div className="relative z-10 bg-white">
         {/* Plans Strip - Inside content sections at top */}
-        <PlansStrip />
+        <PlansStrip onShowPlans={() => setShowPlans(true)} />
         <CreativitySection />
         <IntroducingSection />
         <LatestNewsSection />

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -21,11 +21,10 @@ const Signup = () => {
         <HeroSection />
       </div>
 
-      {/* Plans Strip - Between Hero and Content */}
-      <PlansStrip />
-
       {/* Content Sections - Below Hero */}
       <div className="relative z-10 bg-white">
+        {/* Plans Strip - Inside content sections at top */}
+        <PlansStrip />
         <CreativitySection />
         <IntroducingSection />
         <LatestNewsSection />

--- a/client/pages/TaleTreeExact.tsx
+++ b/client/pages/TaleTreeExact.tsx
@@ -1,0 +1,945 @@
+import React from 'react';
+import {
+  Box,
+  Container,
+  Typography,
+  Button,
+  TextField,
+  Grid,
+  Card,
+  CardMedia,
+  CardContent,
+  AppBar,
+  Toolbar,
+  useTheme,
+  useMediaQuery,
+  Paper,
+  Chip,
+  Avatar,
+  Link,
+  IconButton,
+  InputAdornment,
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  Facebook as FacebookIcon,
+  Twitter as TwitterIcon,
+  Instagram as InstagramIcon,
+  LinkedIn as LinkedInIcon,
+} from '@mui/icons-material';
+
+const TaleTreeExact = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  // Sample data for content sections based on the exact image
+  const latestNews = [
+    {
+      image: 'https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=400&h=250&fit=crop',
+      title: 'We are using my children village'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1547036967-23d11aacaee0?w=400&h=250&fit=crop',
+      title: 'Making their dreams'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1533228100845-08145b01de14?w=400&h=250&fit=crop',
+      title: 'Business are going to Forward trip'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1581726690015-c9861fa5057f?w=400&h=250&fit=crop',
+      title: 'Kids has commented'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=400&h=250&fit=crop',
+      title: 'Applying a Curriculum to Forward trip'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=400&h=250&fit=crop',
+      title: 'Active WITH EXPERTS'
+    },
+  ];
+
+  const parentsImages = [
+    {
+      image: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e?w=400&h=250&fit=crop',
+      title: 'Create space about at home',
+      subtitle: 'July 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1543269664-647912086415?w=400&h=250&fit=crop',
+      title: 'Create space about at home',
+      subtitle: 'July 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1511895426328-dc8714191300?w=400&h=250&fit=crop',
+      title: 'Learn space about at most',
+      subtitle: 'July 18, 2024'
+    },
+  ];
+
+  const educatorsImages = [
+    {
+      image: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=600&h=400&fit=crop',
+      title: 'Transform space about at most',
+      subtitle: 'Aug 8, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1511895426328-dc8714191300?w=400&h=250&fit=crop',
+      title: 'The Different Featured',
+      subtitle: 'Aug 8, 2024'
+    },
+  ];
+
+  const expertsImages = [
+    {
+      image: 'https://images.unsplash.com/photo-1556157382-97eda2d62296?w=400&h=250&fit=crop',
+      title: 'Learn space about at most',
+      subtitle: 'Feb 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1521737711867-e3b97375f902?w=400&h=250&fit=crop',
+      title: 'Create space about at most',
+      subtitle: 'Feb 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1531482615713-2afd69097998?w=400&h=250&fit=crop',
+      title: 'Create space about at most',
+      subtitle: 'Feb 18, 2024'
+    },
+  ];
+
+  return (
+    <Box sx={{ minHeight: '100vh' }}>
+      {/* Header */}
+      <AppBar 
+        position="static" 
+        elevation={0}
+        sx={{ 
+          bgcolor: 'transparent',
+          background: 'linear-gradient(135deg, #1a237e 0%, #283593 50%, #3949ab 100%)',
+          position: 'relative'
+        }}
+      >
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: `
+              radial-gradient(circle at 20% 30%, rgba(255, 107, 53, 0.3) 0%, transparent 50%),
+              radial-gradient(circle at 80% 20%, rgba(79, 195, 247, 0.4) 0%, transparent 50%),
+              radial-gradient(circle at 40% 70%, rgba(255, 193, 7, 0.2) 0%, transparent 50%)
+            `,
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: '10%',
+              left: '10%',
+              width: '20px',
+              height: '20px',
+              background: '#ff6b35',
+              borderRadius: '50%',
+            },
+            '&::after': {
+              content: '""',
+              position: 'absolute',
+              top: '20%',
+              right: '15%',
+              width: '15px',
+              height: '15px',
+              background: '#4fc3f7',
+              borderRadius: '50%',
+            }
+          }}
+        />
+        <Toolbar sx={{ position: 'relative', zIndex: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box
+              sx={{
+                width: 40,
+                height: 40,
+                borderRadius: '50%',
+                bgcolor: '#4fc3f7',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                mr: 1
+              }}
+            >
+              <Typography sx={{ color: 'white', fontWeight: 'bold', fontSize: '1.2rem' }}>
+                T
+              </Typography>
+            </Box>
+            <Typography
+              variant="h5"
+              component="div"
+              sx={{
+                fontWeight: 'bold',
+                color: 'white',
+              }}
+            >
+              TaleTree
+            </Typography>
+          </Box>
+          <Box sx={{ flexGrow: 1 }} />
+          <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.8)', fontSize: '0.8rem' }}>
+            A New Kind of Curriculum for a New Kind of World
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      {/* Hero Section */}
+      <Box
+        sx={{
+          background: 'linear-gradient(135deg, #1a237e 0%, #283593 50%, #3949ab 100%)',
+          minHeight: '80vh',
+          position: 'relative',
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        {/* Decorative background elements */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: `
+              radial-gradient(circle at 20% 30%, rgba(255, 107, 53, 0.3) 0%, transparent 50%),
+              radial-gradient(circle at 80% 20%, rgba(79, 195, 247, 0.4) 0%, transparent 50%),
+              radial-gradient(circle at 40% 70%, rgba(255, 193, 7, 0.2) 0%, transparent 50%)
+            `,
+          }}
+        />
+        
+        {/* Floating decorative elements */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '15%',
+            left: '5%',
+            width: '30px',
+            height: '30px',
+            background: '#ff6b35',
+            borderRadius: '50%',
+            opacity: 0.7,
+          }}
+        />
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '25%',
+            right: '10%',
+            width: '20px',
+            height: '20px',
+            background: '#4fc3f7',
+            borderRadius: '50%',
+            opacity: 0.8,
+          }}
+        />
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: '30%',
+            left: '15%',
+            width: '25px',
+            height: '25px',
+            background: '#ffc107',
+            borderRadius: '50%',
+            opacity: 0.6,
+          }}
+        />
+
+        <Container maxWidth="lg" sx={{ position: 'relative', zIndex: 1 }}>
+          <Grid container spacing={4} alignItems="center">
+            <Grid item xs={12} md={7}>
+              <Box sx={{ color: 'white' }}>
+                <Typography
+                  variant="h2"
+                  component="h1"
+                  sx={{
+                    fontWeight: 'bold',
+                    mb: 3,
+                    fontSize: { xs: '2.5rem', md: '3.5rem' },
+                    lineHeight: 1.1,
+                  }}
+                >
+                  It's time to spark your kid's creativity
+                </Typography>
+                <Typography
+                  variant="h5"
+                  sx={{ 
+                    mb: 4, 
+                    opacity: 0.9,
+                    fontWeight: 400,
+                    fontSize: { xs: '1.2rem', md: '1.5rem' }
+                  }}
+                >
+                  with storytelling and playing
+                </Typography>
+                
+                {/* Search Bar */}
+                <Paper
+                  sx={{
+                    p: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    maxWidth: 500,
+                    borderRadius: '30px',
+                    mb: 3,
+                  }}
+                >
+                  <TextField
+                    fullWidth
+                    placeholder="Find your interests"
+                    variant="standard"
+                    InputProps={{
+                      disableUnderline: true,
+                      sx: { pl: 2, pr: 1 },
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            sx={{
+                              bgcolor: '#ff6b35',
+                              color: 'white',
+                              width: 40,
+                              height: 40,
+                              '&:hover': { bgcolor: '#e55a2b' },
+                            }}
+                          >
+                            <SearchIcon />
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                </Paper>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                  <Chip
+                    label="All Time most liked lesson"
+                    sx={{ 
+                      bgcolor: 'rgba(255,255,255,0.2)', 
+                      color: 'white',
+                      borderRadius: '20px',
+                      fontSize: '0.8rem'
+                    }}
+                  />
+                  <Typography variant="body2" sx={{ opacity: 0.8, fontSize: '0.85rem' }}>
+                    3.2k lessons
+                  </Typography>
+                </Box>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={5}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  position: 'relative',
+                  minHeight: 400,
+                }}
+              >
+                {/* Character illustration container */}
+                <Box
+                  sx={{
+                    position: 'relative',
+                    width: { xs: 300, md: 400 },
+                    height: { xs: 300, md: 400 },
+                  }}
+                >
+                  {/* Green hills background */}
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      height: '60%',
+                      background: 'linear-gradient(to top, #4caf50, #8bc34a)',
+                      borderRadius: '50% 50% 0 0',
+                    }}
+                  />
+                  
+                  {/* Character */}
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: '40%',
+                      left: '50%',
+                      transform: 'translateX(-50%)',
+                      width: 120,
+                      height: 120,
+                      bgcolor: '#4fc3f7',
+                      borderRadius: '50%',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: '4rem',
+                      zIndex: 2,
+                    }}
+                  >
+                    🐰
+                  </Box>
+
+                  {/* Speech bubble */}
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: '10%',
+                      right: '5%',
+                      bgcolor: '#4fc3f7',
+                      color: 'white',
+                      p: 2,
+                      borderRadius: '20px',
+                      maxWidth: 200,
+                      fontSize: '0.8rem',
+                      zIndex: 3,
+                      '&::after': {
+                        content: '""',
+                        position: 'absolute',
+                        bottom: '-10px',
+                        left: '30px',
+                        width: 0,
+                        height: 0,
+                        borderLeft: '10px solid transparent',
+                        borderRight: '10px solid transparent',
+                        borderTop: '10px solid #4fc3f7',
+                      },
+                    }}
+                  >
+                    It's time to spark your kid's creativity and storytelling and playing!
+                  </Box>
+
+                  {/* Decorative trees */}
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      bottom: '10%',
+                      left: '10%',
+                      width: 40,
+                      height: 60,
+                      bgcolor: '#4caf50',
+                      borderRadius: '50% 50% 0 0',
+                      '&::before': {
+                        content: '""',
+                        position: 'absolute',
+                        bottom: -20,
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        width: 8,
+                        height: 20,
+                        bgcolor: '#8d6e63',
+                      }
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      bottom: '15%',
+                      right: '15%',
+                      width: 30,
+                      height: 50,
+                      bgcolor: '#66bb6a',
+                      borderRadius: '50% 50% 0 0',
+                      '&::before': {
+                        content: '""',
+                        position: 'absolute',
+                        bottom: -15,
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        width: 6,
+                        height: 15,
+                        bgcolor: '#8d6e63',
+                      }
+                    }}
+                  />
+                </Box>
+              </Box>
+            </Grid>
+          </Grid>
+        </Container>
+      </Box>
+
+      {/* Creativity Section */}
+      <Container maxWidth="lg" sx={{ py: 8 }}>
+        <Box sx={{ textAlign: 'center', mb: 6 }}>
+          <Typography 
+            variant="h4" 
+            component="h2" 
+            sx={{ 
+              fontWeight: 'bold', 
+              mb: 2,
+              fontSize: { xs: '1.8rem', md: '2.2rem' }
+            }}
+          >
+            Creativity and kindness matter more than ever in the age of{' '}
+            <Box component="span" sx={{ 
+              bgcolor: '#4fc3f7', 
+              color: 'white', 
+              px: 1, 
+              py: 0.5, 
+              borderRadius: 1,
+              display: 'inline-block'
+            }}>
+              AI
+            </Box>
+          </Typography>
+          <Typography variant="h6" sx={{ color: 'text.secondary', maxWidth: 600, mx: 'auto' }}>
+            TaleTree helps your child grow both — and get rewarded for it.
+          </Typography>
+        </Box>
+
+        <Grid container spacing={4} alignItems="center">
+          <Grid item xs={12} md={6}>
+            <Box
+              component="img"
+              src="https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=600&h=400&fit=crop"
+              alt="Children creativity"
+              sx={{
+                width: '100%',
+                height: 350,
+                objectFit: 'cover',
+                borderRadius: 3,
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Typography variant="h4" component="h3" sx={{ fontWeight: 'bold', mb: 3 }}>
+              Introducing TaleTree
+            </Typography>
+            <Typography variant="body1" sx={{ color: 'text.secondary', lineHeight: 1.8, fontSize: '1.1rem' }}>
+              A revolutionary platform that combines storytelling, creativity, and learning 
+              to help children develop essential skills for the future. Through interactive 
+              narratives and engaging activities, kids learn to think creatively, express 
+              themselves, and build emotional intelligence.
+            </Typography>
+          </Grid>
+        </Grid>
+      </Container>
+
+      {/* Latest News Section */}
+      <Box sx={{ bgcolor: '#f8f9fa', py: 8 }}>
+        <Container maxWidth="lg">
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+            <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+              Latest news
+            </Typography>
+            <Button 
+              sx={{ 
+                color: '#4fc3f7', 
+                textTransform: 'none',
+                fontSize: '1rem',
+                fontWeight: 'bold'
+              }}
+            >
+              View all
+            </Button>
+          </Box>
+          <Grid container spacing={3}>
+            {latestNews.map((item, index) => (
+              <Grid item xs={12} sm={6} md={4} key={index}>
+                <Card 
+                  sx={{ 
+                    height: '100%', 
+                    cursor: 'pointer', 
+                    borderRadius: 3,
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                    '&:hover': { 
+                      transform: 'translateY(-4px)', 
+                      transition: 'transform 0.3s',
+                      boxShadow: '0 8px 24px rgba(0,0,0,0.15)'
+                    } 
+                  }}
+                >
+                  <CardMedia
+                    component="img"
+                    height="200"
+                    image={item.image}
+                    alt={item.title}
+                  />
+                  <CardContent sx={{ p: 3 }}>
+                    <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', lineHeight: 1.4 }}>
+                      {item.title}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      </Box>
+
+      {/* Parents Section */}
+      <Container maxWidth="lg" sx={{ py: 8 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+          <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+            Parents
+          </Typography>
+          <Button 
+            sx={{ 
+              color: '#4fc3f7', 
+              textTransform: 'none',
+              fontSize: '1rem',
+              fontWeight: 'bold'
+            }}
+          >
+            View all
+          </Button>
+        </Box>
+        <Grid container spacing={3}>
+          {parentsImages.map((item, index) => (
+            <Grid item xs={12} md={4} key={index}>
+              <Card 
+                sx={{ 
+                  height: '100%', 
+                  cursor: 'pointer',
+                  borderRadius: 3,
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                  '&:hover': { 
+                    transform: 'translateY(-4px)', 
+                    transition: 'transform 0.3s',
+                    boxShadow: '0 8px 24px rgba(0,0,0,0.15)'
+                  } 
+                }}
+              >
+                <CardMedia
+                  component="img"
+                  height="200"
+                  image={item.image}
+                  alt={item.title}
+                />
+                <CardContent sx={{ p: 3 }}>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mb: 1 }}>
+                    {item.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {item.subtitle}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+
+      {/* TaleTree for Educators Section */}
+      <Box sx={{ bgcolor: '#f8f9fa', py: 8 }}>
+        <Container maxWidth="lg">
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+            <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+              TaleTree for Educators
+            </Typography>
+            <Button 
+              sx={{ 
+                color: '#4fc3f7', 
+                textTransform: 'none',
+                fontSize: '1rem',
+                fontWeight: 'bold'
+              }}
+            >
+              View all
+            </Button>
+          </Box>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={6}>
+              <Card 
+                sx={{ 
+                  height: '100%', 
+                  cursor: 'pointer',
+                  borderRadius: 3,
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                  '&:hover': { 
+                    transform: 'translateY(-4px)', 
+                    transition: 'transform 0.3s',
+                    boxShadow: '0 8px 24px rgba(0,0,0,0.15)'
+                  } 
+                }}
+              >
+                <CardMedia
+                  component="img"
+                  height="280"
+                  image={educatorsImages[0].image}
+                  alt={educatorsImages[0].title}
+                />
+                <CardContent sx={{ p: 3 }}>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mb: 1 }}>
+                    {educatorsImages[0].title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {educatorsImages[0].subtitle}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Box
+                sx={{
+                  height: '100%',
+                  minHeight: 400,
+                  background: 'linear-gradient(135deg, #1a237e 0%, #3949ab 100%)',
+                  borderRadius: 3,
+                  p: 4,
+                  color: 'white',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  position: 'relative',
+                  overflow: 'hidden',
+                }}
+              >
+                <Typography variant="h4" component="h3" sx={{ fontWeight: 'bold', mb: 3 }}>
+                  The TaleTree Method
+                </Typography>
+                <Typography variant="body1" sx={{ mb: 4, opacity: 0.9, fontSize: '1.1rem', lineHeight: 1.6 }}>
+                  Our innovative approach combines proven educational methodologies 
+                  with cutting-edge technology to create engaging learning experiences 
+                  that foster creativity and critical thinking.
+                </Typography>
+                <Button
+                  variant="contained"
+                  sx={{ 
+                    bgcolor: '#4fc3f7', 
+                    alignSelf: 'flex-start',
+                    px: 3,
+                    py: 1.5,
+                    borderRadius: '25px',
+                    textTransform: 'none',
+                    fontSize: '1rem',
+                    fontWeight: 'bold'
+                  }}
+                >
+                  Learn More
+                </Button>
+                
+                {/* Decorative circles */}
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    top: -30,
+                    right: -30,
+                    width: 120,
+                    height: 120,
+                    borderRadius: '50%',
+                    bgcolor: 'rgba(79, 195, 247, 0.1)',
+                  }}
+                />
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    bottom: -20,
+                    left: -20,
+                    width: 80,
+                    height: 80,
+                    borderRadius: '50%',
+                    bgcolor: 'rgba(255, 107, 53, 0.1)',
+                  }}
+                />
+              </Box>
+            </Grid>
+          </Grid>
+        </Container>
+      </Box>
+
+      {/* Experts and Friends Section */}
+      <Container maxWidth="lg" sx={{ py: 8 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+          <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+            Experts and Friends
+          </Typography>
+          <Button 
+            sx={{ 
+              color: '#4fc3f7', 
+              textTransform: 'none',
+              fontSize: '1rem',
+              fontWeight: 'bold'
+            }}
+          >
+            View all
+          </Button>
+        </Box>
+        <Grid container spacing={3}>
+          {expertsImages.map((item, index) => (
+            <Grid item xs={12} md={4} key={index}>
+              <Card 
+                sx={{ 
+                  height: '100%', 
+                  cursor: 'pointer',
+                  borderRadius: 3,
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                  '&:hover': { 
+                    transform: 'translateY(-4px)', 
+                    transition: 'transform 0.3s',
+                    boxShadow: '0 8px 24px rgba(0,0,0,0.15)'
+                  } 
+                }}
+              >
+                <CardMedia
+                  component="img"
+                  height="200"
+                  image={item.image}
+                  alt={item.title}
+                />
+                <CardContent sx={{ p: 3 }}>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mb: 1 }}>
+                    {item.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {item.subtitle}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+
+      {/* Footer */}
+      <Box sx={{ bgcolor: '#1a237e', color: 'white', py: 8 }}>
+        <Container maxWidth="lg">
+          <Grid container spacing={4}>
+            <Grid item xs={12} md={4}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <Box
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: '50%',
+                    bgcolor: '#4fc3f7',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Typography sx={{ color: 'white', fontWeight: 'bold', fontSize: '1.2rem' }}>
+                    T
+                  </Typography>
+                </Box>
+                <Typography variant="h5" sx={{ fontWeight: 'bold', color: 'white' }}>
+                  TaleTree Inc.
+                </Typography>
+              </Box>
+              <Typography variant="body2" sx={{ mb: 2, opacity: 0.8, fontSize: '0.9rem' }}>
+                10 E 29th St, Apt 42B, New York, NY 10016 USA
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <IconButton sx={{ color: '#4fc3f7', p: 1 }}>
+                  <FacebookIcon />
+                </IconButton>
+                <IconButton sx={{ color: '#4fc3f7', p: 1 }}>
+                  <TwitterIcon />
+                </IconButton>
+                <IconButton sx={{ color: '#4fc3f7', p: 1 }}>
+                  <InstagramIcon />
+                </IconButton>
+                <IconButton sx={{ color: '#4fc3f7', p: 1 }}>
+                  <LinkedInIcon />
+                </IconButton>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+                Company
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Our Story
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Careers
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Team
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Contact Us
+                </Link>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+                Support
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Getting Started
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Help Center
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Server Status
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                  Bug Reports
+                </Link>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+                Follow us
+              </Typography>
+              <Typography variant="body2" sx={{ opacity: 0.8, mb: 2, fontSize: '0.9rem' }}>
+                Stay updated with our latest news and features
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                <TextField
+                  size="small"
+                  placeholder="Enter your email"
+                  sx={{
+                    flexGrow: 1,
+                    minWidth: 200,
+                    '& .MuiOutlinedInput-root': {
+                      bgcolor: 'white',
+                      borderRadius: '25px',
+                      '& fieldset': { borderColor: 'transparent' },
+                    },
+                  }}
+                />
+                <Button 
+                  variant="contained" 
+                  sx={{ 
+                    bgcolor: '#4fc3f7',
+                    borderRadius: '25px',
+                    px: 3,
+                    textTransform: 'none'
+                  }}
+                >
+                  Subscribe
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+          <Box 
+            sx={{ 
+              mt: 6, 
+              pt: 3, 
+              borderTop: '1px solid rgba(255,255,255,0.1)',
+              display: 'flex', 
+              justifyContent: 'space-between', 
+              alignItems: 'center', 
+              flexWrap: 'wrap', 
+              gap: 2 
+            }}
+          >
+            <Typography variant="body2" sx={{ opacity: 0.6, fontSize: '0.8rem' }}>
+              © 2024 TaleTree Inc. All rights reserved.
+            </Typography>
+            <Typography variant="body2" sx={{ opacity: 0.6, fontSize: '0.8rem' }}>
+              Email: contact@taletree.com
+            </Typography>
+          </Box>
+        </Container>
+      </Box>
+    </Box>
+  );
+};
+
+export default TaleTreeExact;

--- a/client/pages/TaleTreeLanding.tsx
+++ b/client/pages/TaleTreeLanding.tsx
@@ -1,0 +1,664 @@
+import React from 'react';
+import {
+  Box,
+  Container,
+  Typography,
+  Button,
+  TextField,
+  Grid,
+  Card,
+  CardMedia,
+  CardContent,
+  AppBar,
+  Toolbar,
+  IconButton,
+  Menu,
+  MenuItem,
+  useTheme,
+  useMediaQuery,
+  Paper,
+  Chip,
+  Avatar,
+  Link,
+  Divider,
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  Menu as MenuIcon,
+  ArrowForward as ArrowForwardIcon,
+  PlayArrow as PlayArrowIcon,
+  Facebook as FacebookIcon,
+  Twitter as TwitterIcon,
+  Instagram as InstagramIcon,
+  LinkedIn as LinkedInIcon,
+} from '@mui/icons-material';
+
+const TaleTreeLanding = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [mobileMenuAnchor, setMobileMenuAnchor] = React.useState<null | HTMLElement>(null);
+
+  const handleMobileMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setMobileMenuAnchor(event.currentTarget);
+  };
+
+  const handleMobileMenuClose = () => {
+    setMobileMenuAnchor(null);
+  };
+
+  // Sample data for content sections
+  const latestNews = [
+    {
+      image: 'https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=400&h=250&fit=crop',
+      title: 'Why play using my children apps',
+      date: 'Jan 20, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1547036967-23d11aacaee0?w=400&h=250&fit=crop',
+      title: 'Making their dreams come to life'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1533228100845-08145b01de14?w=400&h=250&fit=crop',
+      title: 'Business are going to be tested for education'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1581726690015-c9861fa5057f?w=400&h=250&fit=crop',
+      title: 'Kids has commented'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=400&h=250&fit=crop',
+      title: 'Applying a Curriculum to forward play'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=400&h=250&fit=crop',
+      title: 'Active WITH EXPERTS'
+    },
+  ];
+
+  const parentsSection = [
+    {
+      image: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e?w=400&h=250&fit=crop',
+      title: 'Create space about it at home',
+      subtitle: 'July 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1543269664-647912086415?w=400&h=250&fit=crop',
+      title: 'Create some time at family',
+      subtitle: 'July 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1511895426328-dc8714191300?w=400&h=250&fit=crop',
+      title: 'Learn space about at most',
+      subtitle: 'July 18, 2024'
+    },
+  ];
+
+  const educatorsSection = [
+    {
+      image: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=400&h=250&fit=crop',
+      title: 'Transform space about it at most',
+      subtitle: 'Aug 8, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1511895426328-dc8714191300?w=400&h=250&fit=crop',
+      title: 'The Different featured',
+      subtitle: 'Aug 8, 2024'
+    },
+  ];
+
+  const expertsSection = [
+    {
+      image: 'https://images.unsplash.com/photo-1556157382-97eda2d62296?w=400&h=250&fit=crop',
+      title: 'Learn space about at most',
+      subtitle: 'Feb 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1521737711867-e3b97375f902?w=400&h=250&fit=crop',
+      title: 'Create space about at most',
+      subtitle: 'Feb 18, 2024'
+    },
+    {
+      image: 'https://images.unsplash.com/photo-1531482615713-2afd69097998?w=400&h=250&fit=crop',
+      title: 'Create space about at most',
+      subtitle: 'Feb 18, 2024'
+    },
+  ];
+
+  return (
+    <Box>
+      {/* Header */}
+      <AppBar position="static" sx={{ bgcolor: '#1a237e', boxShadow: 'none' }}>
+        <Toolbar>
+          <Box sx={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
+            <Typography
+              variant="h4"
+              component="div"
+              sx={{
+                fontWeight: 'bold',
+                color: '#4fc3f7',
+                mr: 4,
+              }}
+            >
+              TaleTree
+            </Typography>
+            {!isMobile && (
+              <Box sx={{ display: 'flex', gap: 3 }}>
+                <Link href="#" color="inherit" underline="none">
+                  Home
+                </Link>
+                <Link href="#" color="inherit" underline="none">
+                  About
+                </Link>
+                <Link href="#" color="inherit" underline="none">
+                  Services
+                </Link>
+                <Link href="#" color="inherit" underline="none">
+                  Contact
+                </Link>
+              </Box>
+            )}
+          </Box>
+          {isMobile ? (
+            <IconButton
+              color="inherit"
+              onClick={handleMobileMenuOpen}
+            >
+              <MenuIcon />
+            </IconButton>
+          ) : (
+            <Button variant="contained" sx={{ bgcolor: '#4fc3f7' }}>
+              Get Started
+            </Button>
+          )}
+        </Toolbar>
+        <Menu
+          anchorEl={mobileMenuAnchor}
+          open={Boolean(mobileMenuAnchor)}
+          onClose={handleMobileMenuClose}
+        >
+          <MenuItem onClick={handleMobileMenuClose}>Home</MenuItem>
+          <MenuItem onClick={handleMobileMenuClose}>About</MenuItem>
+          <MenuItem onClick={handleMobileMenuClose}>Services</MenuItem>
+          <MenuItem onClick={handleMobileMenuClose}>Contact</MenuItem>
+        </Menu>
+      </AppBar>
+
+      {/* Hero Section */}
+      <Box
+        sx={{
+          bgcolor: 'linear-gradient(135deg, #1a237e 0%, #3949ab 100%)',
+          background: 'linear-gradient(135deg, #1a237e 0%, #3949ab 100%)',
+          minHeight: '70vh',
+          display: 'flex',
+          alignItems: 'center',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Background decorative elements */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%234fc3f7' fill-opacity='0.1'%3E%3Ccircle cx='30' cy='30' r='4'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
+          }}
+        />
+        
+        <Container maxWidth="lg">
+          <Grid container spacing={4} alignItems="center">
+            <Grid item xs={12} md={6}>
+              <Box sx={{ color: 'white', zIndex: 1, position: 'relative' }}>
+                <Typography
+                  variant="h6"
+                  sx={{ color: '#4fc3f7', mb: 2, fontWeight: 500 }}
+                >
+                  A New Kind of Curriculum for a New Kind of World
+                </Typography>
+                <Typography
+                  variant="h2"
+                  component="h1"
+                  sx={{
+                    fontWeight: 'bold',
+                    mb: 3,
+                    fontSize: { xs: '2.5rem', md: '3.5rem' },
+                    lineHeight: 1.2,
+                  }}
+                >
+                  It's time to spark your kid's creativity
+                </Typography>
+                <Typography
+                  variant="h6"
+                  sx={{ mb: 4, opacity: 0.9, maxWidth: 500 }}
+                >
+                  with storytelling and playing
+                </Typography>
+                
+                {/* Search Bar */}
+                <Paper
+                  sx={{
+                    p: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    maxWidth: 500,
+                    borderRadius: 3,
+                  }}
+                >
+                  <TextField
+                    fullWidth
+                    placeholder="Find your interests"
+                    variant="standard"
+                    InputProps={{
+                      disableUnderline: true,
+                      sx: { pl: 2 },
+                    }}
+                  />
+                  <IconButton
+                    sx={{
+                      bgcolor: '#ff6b35',
+                      color: 'white',
+                      '&:hover': { bgcolor: '#e55a2b' },
+                      mr: 1,
+                    }}
+                  >
+                    <SearchIcon />
+                  </IconButton>
+                </Paper>
+
+                <Box sx={{ mt: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <Chip
+                    label="All time most liked lesson"
+                    sx={{ bgcolor: 'rgba(255,255,255,0.2)', color: 'white' }}
+                  />
+                  <Typography variant="body2" sx={{ opacity: 0.8 }}>
+                    3.7k lessons
+                  </Typography>
+                </Box>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  minHeight: 400,
+                }}
+              >
+                {/* Placeholder for the cute character illustration */}
+                <Box
+                  sx={{
+                    width: { xs: 300, md: 400 },
+                    height: { xs: 300, md: 400 },
+                    borderRadius: '50%',
+                    bgcolor: 'rgba(79, 195, 247, 0.1)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    position: 'relative',
+                  }}
+                >
+                  <Avatar
+                    sx={{
+                      width: { xs: 150, md: 200 },
+                      height: { xs: 150, md: 200 },
+                      bgcolor: '#4fc3f7',
+                      fontSize: { xs: '4rem', md: '6rem' },
+                    }}
+                  >
+                    🐰
+                  </Avatar>
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: '20%',
+                      right: '10%',
+                      bgcolor: '#4fc3f7',
+                      color: 'white',
+                      p: 1,
+                      borderRadius: 2,
+                      fontSize: '0.875rem',
+                      '&::after': {
+                        content: '""',
+                        position: 'absolute',
+                        bottom: '-8px',
+                        left: '20px',
+                        width: 0,
+                        height: 0,
+                        borderLeft: '8px solid transparent',
+                        borderRight: '8px solid transparent',
+                        borderTop: '8px solid #4fc3f7',
+                      },
+                    }}
+                  >
+                    It's time to spark your kid's creativity and storytelling and play!
+                  </Box>
+                </Box>
+              </Box>
+            </Grid>
+          </Grid>
+        </Container>
+      </Box>
+
+      {/* Creativity Section */}
+      <Container maxWidth="lg" sx={{ py: 8 }}>
+        <Box sx={{ textAlign: 'center', mb: 6 }}>
+          <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold', mb: 2 }}>
+            Creativity and kindness matter more than ever in the age of{' '}
+            <Box component="span" sx={{ color: '#4fc3f7' }}>AI</Box>
+          </Typography>
+          <Typography variant="h6" sx={{ color: 'text.secondary', maxWidth: 600, mx: 'auto' }}>
+            TaleTree helps your child grow both — and get rewarded for it.
+          </Typography>
+        </Box>
+
+        <Grid container spacing={4} alignItems="center">
+          <Grid item xs={12} md={6}>
+            <Box
+              component="img"
+              src="https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=600&h=400&fit=crop"
+              alt="Children playing"
+              sx={{
+                width: '100%',
+                height: 400,
+                objectFit: 'cover',
+                borderRadius: 2,
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Typography variant="h4" component="h3" sx={{ fontWeight: 'bold', mb: 3 }}>
+              Introducing TaleTree
+            </Typography>
+            <Typography variant="body1" sx={{ color: 'text.secondary', lineHeight: 1.8 }}>
+              A revolutionary platform that combines storytelling, creativity, and learning 
+              to help children develop essential skills for the future. Through interactive 
+              narratives and engaging activities, kids learn to think creatively, express 
+              themselves, and build emotional intelligence.
+            </Typography>
+          </Grid>
+        </Grid>
+      </Container>
+
+      {/* Latest News Section */}
+      <Box sx={{ bgcolor: 'grey.50', py: 8 }}>
+        <Container maxWidth="lg">
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+            <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+              Latest news
+            </Typography>
+            <Button endIcon={<ArrowForwardIcon />}>View all</Button>
+          </Box>
+          <Grid container spacing={3}>
+            {latestNews.map((item, index) => (
+              <Grid item xs={12} sm={6} md={4} key={index}>
+                <Card sx={{ height: '100%', cursor: 'pointer', '&:hover': { transform: 'translateY(-4px)', transition: 'transform 0.3s' } }}>
+                  <CardMedia
+                    component="img"
+                    height="200"
+                    image={item.image}
+                    alt={item.title}
+                  />
+                  <CardContent>
+                    <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mb: 1 }}>
+                      {item.title}
+                    </Typography>
+                    {item.date && (
+                      <Typography variant="body2" color="text.secondary">
+                        {item.date}
+                      </Typography>
+                    )}
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      </Box>
+
+      {/* Parents Section */}
+      <Container maxWidth="lg" sx={{ py: 8 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+          <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+            Parents
+          </Typography>
+          <Button endIcon={<ArrowForwardIcon />}>View all</Button>
+        </Box>
+        <Grid container spacing={3}>
+          {parentsSection.map((item, index) => (
+            <Grid item xs={12} md={4} key={index}>
+              <Card sx={{ height: '100%', cursor: 'pointer', '&:hover': { transform: 'translateY(-4px)', transition: 'transform 0.3s' } }}>
+                <CardMedia
+                  component="img"
+                  height="200"
+                  image={item.image}
+                  alt={item.title}
+                />
+                <CardContent>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mb: 1 }}>
+                    {item.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {item.subtitle}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+
+      {/* TaleTree for Educators Section */}
+      <Box sx={{ bgcolor: 'grey.50', py: 8 }}>
+        <Container maxWidth="lg">
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+            <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+              TaleTree for Educators
+            </Typography>
+            <Button endIcon={<ArrowForwardIcon />}>View all</Button>
+          </Box>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={6}>
+              <Card sx={{ height: '100%', cursor: 'pointer', '&:hover': { transform: 'translateY(-4px)', transition: 'transform 0.3s' } }}>
+                <CardMedia
+                  component="img"
+                  height="250"
+                  image="https://images.unsplash.com/photo-1560472354-b33ff0c44a43?w=600&h=400&fit=crop"
+                  alt="Educators"
+                />
+                <CardContent>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mb: 1 }}>
+                    Transform space about at most
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Aug 8, 2024
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Box
+                sx={{
+                  height: '100%',
+                  background: 'linear-gradient(135deg, #1a237e 0%, #3949ab 100%)',
+                  borderRadius: 2,
+                  p: 4,
+                  color: 'white',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  position: 'relative',
+                  overflow: 'hidden',
+                }}
+              >
+                <Typography variant="h5" component="h3" sx={{ fontWeight: 'bold', mb: 2 }}>
+                  The TaleTree Method
+                </Typography>
+                <Typography variant="body1" sx={{ mb: 3, opacity: 0.9 }}>
+                  Our innovative approach combines proven educational methodologies 
+                  with cutting-edge technology to create engaging learning experiences.
+                </Typography>
+                <Button
+                  variant="contained"
+                  sx={{ bgcolor: '#4fc3f7', alignSelf: 'flex-start' }}
+                  startIcon={<PlayArrowIcon />}
+                >
+                  Learn More
+                </Button>
+                {/* Decorative elements */}
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    top: -20,
+                    right: -20,
+                    width: 100,
+                    height: 100,
+                    borderRadius: '50%',
+                    bgcolor: 'rgba(79, 195, 247, 0.1)',
+                  }}
+                />
+              </Box>
+            </Grid>
+          </Grid>
+        </Container>
+      </Box>
+
+      {/* Experts and Friends Section */}
+      <Container maxWidth="lg" sx={{ py: 8 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+          <Typography variant="h4" component="h2" sx={{ fontWeight: 'bold' }}>
+            Experts and Friends
+          </Typography>
+          <Button endIcon={<ArrowForwardIcon />}>View all</Button>
+        </Box>
+        <Grid container spacing={3}>
+          {expertsSection.map((item, index) => (
+            <Grid item xs={12} md={4} key={index}>
+              <Card sx={{ height: '100%', cursor: 'pointer', '&:hover': { transform: 'translateY(-4px)', transition: 'transform 0.3s' } }}>
+                <CardMedia
+                  component="img"
+                  height="200"
+                  image={item.image}
+                  alt={item.title}
+                />
+                <CardContent>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mb: 1 }}>
+                    {item.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {item.subtitle}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+
+      {/* Footer */}
+      <Box sx={{ bgcolor: '#1a237e', color: 'white', py: 6 }}>
+        <Container maxWidth="lg">
+          <Grid container spacing={4}>
+            <Grid item xs={12} md={4}>
+              <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 2, color: '#4fc3f7' }}>
+                TaleTree Inc.
+              </Typography>
+              <Typography variant="body2" sx={{ mb: 2, opacity: 0.8 }}>
+                10 E 29th St, Apt 42B, New York, NY 10016 USA
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <IconButton sx={{ color: '#4fc3f7' }}>
+                  <FacebookIcon />
+                </IconButton>
+                <IconButton sx={{ color: '#4fc3f7' }}>
+                  <TwitterIcon />
+                </IconButton>
+                <IconButton sx={{ color: '#4fc3f7' }}>
+                  <InstagramIcon />
+                </IconButton>
+                <IconButton sx={{ color: '#4fc3f7' }}>
+                  <LinkedInIcon />
+                </IconButton>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+                Company
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Our Story
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Careers
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Team
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Contact Us
+                </Link>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+                Support
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Getting Started
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Help Center
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Server Status
+                </Link>
+                <Link href="#" color="inherit" underline="none" sx={{ opacity: 0.8 }}>
+                  Bug Reports
+                </Link>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 2 }}>
+                Follow us
+              </Typography>
+              <Typography variant="body2" sx={{ opacity: 0.8, mb: 2 }}>
+                Stay updated with our latest news and features
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <TextField
+                  size="small"
+                  placeholder="Enter your email"
+                  sx={{
+                    flexGrow: 1,
+                    '& .MuiOutlinedInput-root': {
+                      bgcolor: 'white',
+                      '& fieldset': { borderColor: 'transparent' },
+                    },
+                  }}
+                />
+                <Button variant="contained" sx={{ bgcolor: '#4fc3f7' }}>
+                  Subscribe
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+          <Divider sx={{ my: 4, borderColor: 'rgba(255,255,255,0.1)' }} />
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
+            <Typography variant="body2" sx={{ opacity: 0.6 }}>
+              © 2024 TaleTree Inc. All rights reserved.
+            </Typography>
+            <Typography variant="body2" sx={{ opacity: 0.6 }}>
+              Email: contact@taletree.com
+            </Typography>
+          </Box>
+        </Container>
+      </Box>
+    </Box>
+  );
+};
+
+export default TaleTreeLanding;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "fusion-starter",
       "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.2.0",
+        "@mui/material": "^7.2.0",
         "@types/multer": "^2.0.0",
         "express": "^4.18.2",
         "heic2any": "^0.0.4",
@@ -105,12 +109,141 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -120,6 +253,152 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "dev": true
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.4",
@@ -607,35 +886,19 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -643,14 +906,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -676,6 +937,251 @@
       "peerDependencies": {
         "three": ">= 0.159.0"
       }
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.2.0.tgz",
+      "integrity": "sha512-d49s7kEgI5iX40xb2YPazANvo7Bx0BLg/MNRwv+7BVpZUzXj1DaVCKlQTDex3gy/0jsCb4w7AY2uH4t4AJvSog==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.2.0.tgz",
+      "integrity": "sha512-gRCspp3pfjHQyTmSOmYw7kUQTd9Udpdan4R8EnZvqPeoAtHnPzkvjBrBqzKaoAbbBp5bGF7BcD18zZJh4nwu0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.2.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.2.0.tgz",
+      "integrity": "sha512-NTuyFNen5Z2QY+I242MDZzXnFIVIR6ERxo7vntFi9K1wCgSwvIl0HcAO2OOydKqqKApE6omRiYhpny1ZhGuH7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/core-downloads-tracker": "^7.2.0",
+        "@mui/system": "^7.2.0",
+        "@mui/types": "^7.4.4",
+        "@mui/utils": "^7.2.0",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^7.2.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT"
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.2.0.tgz",
+      "integrity": "sha512-y6N1Yt3T5RMxVFnCh6+zeSWBuQdNDm5/UlM0EAYZzZR/1u+XKJWYQmbpx4e+F+1EpkYi3Nk8KhPiQDi83M3zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.2.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.2.0.tgz",
+      "integrity": "sha512-yq08xynbrNYcB1nBcW9Fn8/h/iniM3ewRguGJXPIAbHvxEF7Pz95kbEEOAAhwzxMX4okhzvHmk0DFuC5ayvgIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.2.0.tgz",
+      "integrity": "sha512-PG7cm/WluU6RAs+gNND2R9vDwNh+ERWxPkqTaiXQJGIFAyJ+VxhyKfzpdZNk0z0XdmBxxi9KhFOpgxjehf/O0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/private-theming": "^7.2.0",
+        "@mui/styled-engine": "^7.2.0",
+        "@mui/types": "^7.4.4",
+        "@mui/utils": "^7.2.0",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-p63yhbX52MO/ajXC7hDHJA5yjzJekvWD3q4YDLl1rSg+OXLczMYPvTuSuviPRCgRX8+E42RXz1D/dz9SxPSlWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.2.0.tgz",
+      "integrity": "sha512-O0i1GQL6MDzhKdy9iAu5Yr0Sz1wZjROH1o3aoztuivdCXqEeQYnEjTDiRLGuFxI9zrUbTHBwobMyQH5sNtyacw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/types": "^7.4.4",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -724,6 +1230,16 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3415,9 +3931,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "dev": true,
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -3456,6 +3979,15 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -3795,6 +4327,21 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4029,6 +4576,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -4148,7 +4704,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4666,6 +5221,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -4693,6 +5254,31 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-env": {
@@ -4742,7 +5328,6 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -4868,7 +5453,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4947,7 +5531,6 @@
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
@@ -5034,6 +5617,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -5129,6 +5721,18 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -5338,6 +5942,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
     },
     "node_modules/foreground-child": {
@@ -5597,6 +6207,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -5661,6 +6280,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5701,6 +6336,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5718,7 +6359,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -5828,6 +6468,24 @@
       "version": "4.0.0",
       "license": "MIT"
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -5855,7 +6513,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -6275,6 +6932,36 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6296,7 +6983,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -6321,6 +7007,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -6355,7 +7050,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6886,7 +7580,6 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
@@ -6995,7 +7688,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -7010,6 +7702,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -7330,6 +8031,15 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "dev": true,
@@ -7511,6 +8221,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -7538,7 +8254,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.2.0",
+    "@mui/material": "^7.2.0",
     "@types/multer": "^2.0.0",
     "express": "^4.18.2",
     "heic2any": "^0.0.4",


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user requested several UI improvements and new features for a TaleTree application:

1. **Navigation improvements**: Replace toggle buttons with specific images and improve sidebar positioning
2. **Plan strip implementation**: Add a plan selection strip to the signup page matching a specific design
3. **Signup flow enhancement**: Create a signup page with plan selection that shows only plans and footer when accessed via plan selection
4. **Companion selection**: Implement a companion selection modal for the TaleTree experience

## Code changes

- **New routes**: Added `/taletree`, `/taletree-exact`, and `/signup` routes to App.tsx
- **Chat positioning**: Updated SimplifiedChatContainer positioning - moved companion character and AI messages to bottom positioning (bottom-[-150px] and bottom-[-20px])
- **New components**: 
  - Created `BunnyCharacter.tsx` - animated green bunny character component
  - Created `CompanionSelectionModal.tsx` - circular companion selection wheel with 6 different companions (Letsgo, Rushmore, Uni, Cody, Doma, Rooty)
- **Dependencies**: Added Material-UI packages (@mui/material, @mui/icons-material, @emotion/react, @emotion/styled) for enhanced UI components
- **New pages**: Added TaleTreeLanding, TaleTreeExact, and Signup page components (referenced but implementation not shown in diff)

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/9b625af51c774516a79eba8a0b14359f/zenith-studio)

👀 [Preview Link](https://9b625af51c774516a79eba8a0b14359f-zenith-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9b625af51c774516a79eba8a0b14359f</projectId>-->
<!--<branchName>zenith-studio</branchName>-->