### PR TITLE
Add MUI companion selection modal with circular layout

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -32,6 +32,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/signup" element={<Signup />} />
+          <Route path="/signup-mui" element={<SignupMui />} />
           <Route path="/space-companion" element={<SpaceCompanionDemo />} />
           <Route path="/magical-portal" element={<MagicalPortalDemo />} />
           <Route path="/arch-portal" element={<ArchPortalDemo />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -9,6 +9,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Signup from "./pages/Signup";
+import SignupMui from "./pages/SignupMui";
 import SpaceCompanionDemo from "./pages/SpaceCompanionDemo";
 import MagicalPortalDemo from "./pages/MagicalPortalDemo";
 import ArchPortalDemo from "./pages/ArchPortalDemo";

--- a/client/components/signup-mui/MuiCompanionSelectionModal.jsx
+++ b/client/components/signup-mui/MuiCompanionSelectionModal.jsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
-import { Box, Modal, IconButton, Chip, Typography, Tooltip } from "@mui/material";
+import {
+  Box,
+  Modal,
+  IconButton,
+  Chip,
+  Typography,
+  Tooltip,
+} from "@mui/material";
 import { Close } from "@mui/icons-material";
 
 export function MuiCompanionSelectionModal({
@@ -123,7 +130,14 @@ export function MuiCompanionSelectionModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", mb: 3 }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            mb: 3,
+          }}
+        >
           <Chip
             label="TaleTree Friends"
             sx={{
@@ -136,7 +150,15 @@ export function MuiCompanionSelectionModal({
         </Box>
 
         {/* Wheel Container */}
-        <Box sx={{ flex: 1, position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Box
+          sx={{
+            flex: 1,
+            position: "relative",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
           {/* Center Close Button */}
           <IconButton
             onClick={onClose}
@@ -175,7 +197,13 @@ export function MuiCompanionSelectionModal({
               onMouseLeave={() => setHoveredCompanion(null)}
               onClick={() => handleCompanionSelect(companion.id)}
             >
-              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                }}
+              >
                 {/* Companion Icon */}
                 <Box
                   sx={{
@@ -235,7 +263,8 @@ export function MuiCompanionSelectionModal({
                   p: 1.5,
                   borderRadius: "8px",
                   maxWidth: "300px",
-                  boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+                  boxShadow:
+                    "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
                   position: "relative",
                 }}
               >

--- a/client/components/signup-mui/MuiCompanionSelectionModal.jsx
+++ b/client/components/signup-mui/MuiCompanionSelectionModal.jsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { Box, Modal, IconButton, Chip, Typography, Tooltip } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+export function MuiCompanionSelectionModal({
+  isOpen,
+  onClose,
+  onSelectCompanion,
+}) {
+  const [hoveredCompanion, setHoveredCompanion] = useState(null);
+
+  // Calculate circular positions using trigonometry
+  const radius = 150; // Radius of the circle
+  const centerX = 0; // Center X (will be positioned relative to container center)
+  const centerY = 0; // Center Y (will be positioned relative to container center)
+
+  const companionActions = [
+    {
+      id: "letsgo",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
+      label: "Letsgo",
+      color: "#22c55e",
+      description: "A friendly and energetic companion ready for adventures.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "rushmore",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800",
+      label: "Rushmore",
+      color: "#3b82f6",
+      description:
+        "A wise and thoughtful companion who loves to explore knowledge.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "uni",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800",
+      label: "Uni",
+      color: "#ec4899",
+      description:
+        "A magical and creative companion with a love for imagination.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "cody",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800",
+      label: "Cody",
+      color: "#ef4444",
+      description: "A brave and determined companion ready for any challenge.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "doma",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800",
+      label: "Doma",
+      color: "#06b6d4",
+      description: "A calm and peaceful companion who brings tranquility.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((5 * Math.PI) / 6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos((5 * Math.PI) / 6)}px)`,
+      },
+    },
+    {
+      id: "rooty",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800",
+      label: "Rooty",
+      color: "#f97316",
+      description: "A grounded and nurturing companion connected to nature.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((-5 * Math.PI) / 6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos((-5 * Math.PI) / 6)}px)`,
+      },
+    },
+  ];
+
+  const getHoveredCompanion = () => {
+    return companionActions.find(
+      (companion) => companion.id === hoveredCompanion,
+    );
+  };
+
+  const handleCompanionSelect = (companionId) => {
+    onSelectCompanion?.(companionId);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backdropFilter: "blur(8px)",
+        bgcolor: "rgba(0, 0, 0, 0.4)",
+      }}
+    >
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: "80rem",
+          height: "100%",
+          maxHeight: "90vh",
+          display: "flex",
+          flexDirection: "column",
+          p: 2,
+          position: "relative",
+          outline: "none",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", mb: 3 }}>
+          <Chip
+            label="TaleTree Friends"
+            sx={{
+              bgcolor: "rgba(255, 255, 255, 0.2)",
+              color: "white",
+              backdropFilter: "blur(8px)",
+              fontSize: "12px",
+            }}
+          />
+        </Box>
+
+        {/* Wheel Container */}
+        <Box sx={{ flex: 1, position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+          {/* Center Close Button */}
+          <IconButton
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              width: 64,
+              height: 64,
+              bgcolor: "#ef4444",
+              "&:hover": {
+                bgcolor: "#dc2626",
+              },
+              borderRadius: "50%",
+              zIndex: 20,
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              transition: "background-color 0.2s ease",
+              boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)",
+            }}
+          >
+            <Close sx={{ width: 32, height: 32, color: "white" }} />
+          </IconButton>
+
+          {/* Companion Items - Circular Layout */}
+          {companionActions.map((companion) => (
+            <Box
+              key={companion.id}
+              sx={{
+                position: "absolute",
+                cursor: "pointer",
+                top: companion.position.top,
+                left: companion.position.left,
+                transform: "translate(-50%, -50%)",
+              }}
+              onMouseEnter={() => setHoveredCompanion(companion.id)}
+              onMouseLeave={() => setHoveredCompanion(null)}
+              onClick={() => handleCompanionSelect(companion.id)}
+            >
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                {/* Companion Icon */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    transition: "transform 0.2s ease",
+                    "&:hover": {
+                      transform: "scale(1.1)",
+                    },
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={companion.icon}
+                    alt={companion.label}
+                    sx={{
+                      width: 64,
+                      height: 64,
+                      objectFit: "contain",
+                    }}
+                  />
+                </Box>
+                {/* Label */}
+                <Chip
+                  label={companion.label}
+                  sx={{
+                    bgcolor: companion.color,
+                    color: "white",
+                    fontSize: "14px",
+                    fontWeight: 500,
+                    mt: 1,
+                  }}
+                />
+              </Box>
+            </Box>
+          ))}
+
+          {/* Hover Description */}
+          {hoveredCompanion && (
+            <Box
+              sx={{
+                position: "absolute",
+                zIndex: 30,
+                transition: "opacity 0.15s ease-in-out",
+                opacity: 1,
+                top: `calc(${getHoveredCompanion()?.position.top} - 80px)`,
+                left: getHoveredCompanion()?.position.left,
+                transform: "translate(-50%, 0)",
+                pointerEvents: "none",
+              }}
+            >
+              <Box
+                sx={{
+                  bgcolor: getHoveredCompanion()?.color,
+                  color: "white",
+                  p: 1.5,
+                  borderRadius: "8px",
+                  maxWidth: "300px",
+                  boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+                  position: "relative",
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "12px",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {getHoveredCompanion()?.description}
+                </Typography>
+                {/* Tooltip arrow */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: "100%",
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    width: 0,
+                    height: 0,
+                    borderLeft: "12px solid transparent",
+                    borderRight: "12px solid transparent",
+                    borderTop: `12px solid ${getHoveredCompanion()?.color}`,
+                  }}
+                />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/client/components/signup-mui/MuiCompanionSelectionModal.tsx
+++ b/client/components/signup-mui/MuiCompanionSelectionModal.tsx
@@ -1,0 +1,287 @@
+import { useState } from "react";
+import { Box, Modal, IconButton, Chip, Typography, Tooltip } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+interface CompanionAction {
+  id: string;
+  icon: string;
+  label: string;
+  color: string;
+  description: string;
+  position: { top: string; left: string };
+}
+
+interface MuiCompanionSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectCompanion?: (companionId: string) => void;
+}
+
+export function MuiCompanionSelectionModal({
+  isOpen,
+  onClose,
+  onSelectCompanion,
+}: MuiCompanionSelectionModalProps) {
+  const [hoveredCompanion, setHoveredCompanion] = useState<string | null>(null);
+
+  // Calculate circular positions using trigonometry
+  const radius = 150; // Radius of the circle
+  const centerX = 0; // Center X (will be positioned relative to container center)
+  const centerY = 0; // Center Y (will be positioned relative to container center)
+
+  const companionActions: CompanionAction[] = [
+    {
+      id: "letsgo",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
+      label: "Letsgo",
+      color: "#22c55e",
+      description: "A friendly and energetic companion ready for adventures.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "rushmore",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800",
+      label: "Rushmore",
+      color: "#3b82f6",
+      description:
+        "A wise and thoughtful companion who loves to explore knowledge.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "uni",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800",
+      label: "Uni",
+      color: "#ec4899",
+      description:
+        "A magical and creative companion with a love for imagination.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "cody",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800",
+      label: "Cody",
+      color: "#ef4444",
+      description: "A brave and determined companion ready for any challenge.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "doma",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800",
+      label: "Doma",
+      color: "#06b6d4",
+      description: "A calm and peaceful companion who brings tranquility.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((5 * Math.PI) / 6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos((5 * Math.PI) / 6)}px)`,
+      },
+    },
+    {
+      id: "rooty",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800",
+      label: "Rooty",
+      color: "#f97316",
+      description: "A grounded and nurturing companion connected to nature.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((-5 * Math.PI) / 6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos((-5 * Math.PI) / 6)}px)`,
+      },
+    },
+  ];
+
+  const getHoveredCompanion = () => {
+    return companionActions.find(
+      (companion) => companion.id === hoveredCompanion,
+    );
+  };
+
+  const handleCompanionSelect = (companionId: string) => {
+    onSelectCompanion?.(companionId);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backdropFilter: "blur(8px)",
+        bgcolor: "rgba(0, 0, 0, 0.4)",
+      }}
+    >
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: "80rem",
+          height: "100%",
+          maxHeight: "90vh",
+          display: "flex",
+          flexDirection: "column",
+          p: 2,
+          position: "relative",
+          outline: "none",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", mb: 3 }}>
+          <Chip
+            label="TaleTree Friends"
+            sx={{
+              bgcolor: "rgba(255, 255, 255, 0.2)",
+              color: "white",
+              backdropFilter: "blur(8px)",
+              fontSize: "12px",
+            }}
+          />
+        </Box>
+
+        {/* Wheel Container */}
+        <Box sx={{ flex: 1, position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+          {/* Center Close Button */}
+          <IconButton
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              width: 64,
+              height: 64,
+              bgcolor: "#ef4444",
+              "&:hover": {
+                bgcolor: "#dc2626",
+              },
+              borderRadius: "50%",
+              zIndex: 20,
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              transition: "background-color 0.2s ease",
+              boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)",
+            }}
+          >
+            <Close sx={{ width: 32, height: 32, color: "white" }} />
+          </IconButton>
+
+          {/* Companion Items - Circular Layout */}
+          {companionActions.map((companion) => (
+            <Box
+              key={companion.id}
+              sx={{
+                position: "absolute",
+                cursor: "pointer",
+                top: companion.position.top,
+                left: companion.position.left,
+                transform: "translate(-50%, -50%)",
+              }}
+              onMouseEnter={() => setHoveredCompanion(companion.id)}
+              onMouseLeave={() => setHoveredCompanion(null)}
+              onClick={() => handleCompanionSelect(companion.id)}
+            >
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                {/* Companion Icon */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    transition: "transform 0.2s ease",
+                    "&:hover": {
+                      transform: "scale(1.1)",
+                    },
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={companion.icon}
+                    alt={companion.label}
+                    sx={{
+                      width: 64,
+                      height: 64,
+                      objectFit: "contain",
+                    }}
+                  />
+                </Box>
+                {/* Label */}
+                <Chip
+                  label={companion.label}
+                  sx={{
+                    bgcolor: companion.color,
+                    color: "white",
+                    fontSize: "14px",
+                    fontWeight: 500,
+                    mt: 1,
+                  }}
+                />
+              </Box>
+            </Box>
+          ))}
+
+          {/* Hover Description */}
+          {hoveredCompanion && (
+            <Box
+              sx={{
+                position: "absolute",
+                zIndex: 30,
+                transition: "opacity 0.15s ease-in-out",
+                opacity: 1,
+                top: `calc(${getHoveredCompanion()?.position.top} - 80px)`,
+                left: getHoveredCompanion()?.position.left,
+                transform: "translate(-50%, 0)",
+                pointerEvents: "none",
+              }}
+            >
+              <Box
+                sx={{
+                  bgcolor: getHoveredCompanion()?.color,
+                  color: "white",
+                  p: 1.5,
+                  borderRadius: "8px",
+                  maxWidth: "300px",
+                  boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+                  position: "relative",
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "12px",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {getHoveredCompanion()?.description}
+                </Typography>
+                {/* Tooltip arrow */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: "100%",
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    width: 0,
+                    height: 0,
+                    borderLeft: "12px solid transparent",
+                    borderRight: "12px solid transparent",
+                    borderTop: `12px solid ${getHoveredCompanion()?.color}`,
+                  }}
+                />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/client/components/signup-mui/MuiCreativitySection.jsx
+++ b/client/components/signup-mui/MuiCreativitySection.jsx
@@ -1,0 +1,44 @@
+import { Box, Container, Typography, Chip } from "@mui/material";
+
+const MuiCreativitySection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 4, textAlign: "center" }}>
+      <Typography
+        variant="body1"
+        sx={{
+          color: "#374151",
+          mb: 1,
+          fontSize: "16px",
+          lineHeight: 1.5,
+        }}
+      >
+        <Box component="span" sx={{ fontWeight: 600 }}>
+          Creativity and kindness matter more than score
+        </Box>{" "}
+        in the age of{" "}
+        <Chip
+          label="AI"
+          sx={{
+            bgcolor: "#f3e8ff",
+            color: "#7c3aed",
+            fontSize: "14px",
+            height: "24px",
+            mx: 0.5,
+          }}
+        />
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "#6b7280",
+          fontSize: "16px",
+          lineHeight: 1.5,
+        }}
+      >
+        TaleTree helps your child grow both — and get rewarded for it.
+      </Typography>
+    </Container>
+  );
+};
+
+export default MuiCreativitySection;

--- a/client/components/signup-mui/MuiCreativitySection.tsx
+++ b/client/components/signup-mui/MuiCreativitySection.tsx
@@ -1,0 +1,44 @@
+import { Box, Container, Typography, Chip } from "@mui/material";
+
+const MuiCreativitySection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 4, textAlign: "center" }}>
+      <Typography
+        variant="body1"
+        sx={{
+          color: "#374151",
+          mb: 1,
+          fontSize: "16px",
+          lineHeight: 1.5,
+        }}
+      >
+        <Box component="span" sx={{ fontWeight: 600 }}>
+          Creativity and kindness matter more than score
+        </Box>{" "}
+        in the age of{" "}
+        <Chip
+          label="AI"
+          sx={{
+            bgcolor: "#f3e8ff",
+            color: "#7c3aed",
+            fontSize: "14px",
+            height: "24px",
+            mx: 0.5,
+          }}
+        />
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "#6b7280",
+          fontSize: "16px",
+          lineHeight: 1.5,
+        }}
+      >
+        TaleTree helps your child grow both — and get rewarded for it.
+      </Typography>
+    </Container>
+  );
+};
+
+export default MuiCreativitySection;

--- a/client/components/signup-mui/MuiDecorativeStars.jsx
+++ b/client/components/signup-mui/MuiDecorativeStars.jsx
@@ -1,0 +1,135 @@
+import { Box } from "@mui/material";
+
+const MuiDecorativeStars = () => {
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        inset: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+        zIndex: 5,
+      }}
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          top: 80,
+          left: 40,
+          width: 8,
+          height: 8,
+          bgcolor: "#f472b6",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.7,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 128,
+          right: 80,
+          width: 4,
+          height: 4,
+          bgcolor: "#facc15",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.8,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 64,
+          right: 128,
+          width: 12,
+          height: 12,
+          bgcolor: "#fb923c",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.6,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 160,
+          left: 128,
+          width: 8,
+          height: 8,
+          bgcolor: "#c084fc",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.75,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 96,
+          left: "33.33%",
+          width: 4,
+          height: 4,
+          bgcolor: "#22d3ee",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.9,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 112,
+          right: "25%",
+          width: 8,
+          height: 8,
+          bgcolor: "#fbb6ce",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.65,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 240,
+          left: "25%",
+          width: 4,
+          height: 4,
+          bgcolor: "#60a5fa",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.8,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 48,
+          left: "50%",
+          width: 8,
+          height: 8,
+          bgcolor: "#4ade80",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.7,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 192,
+          right: "33.33%",
+          width: 4,
+          height: 4,
+          bgcolor: "#f87171",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.85,
+        }}
+      />
+    </Box>
+  );
+};
+
+export default MuiDecorativeStars;

--- a/client/components/signup-mui/MuiDecorativeStars.tsx
+++ b/client/components/signup-mui/MuiDecorativeStars.tsx
@@ -1,0 +1,135 @@
+import { Box } from "@mui/material";
+
+const MuiDecorativeStars = () => {
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        inset: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+        zIndex: 5,
+      }}
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          top: 80,
+          left: 40,
+          width: 8,
+          height: 8,
+          bgcolor: "#f472b6",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.7,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 128,
+          right: 80,
+          width: 4,
+          height: 4,
+          bgcolor: "#facc15",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.8,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 64,
+          right: 128,
+          width: 12,
+          height: 12,
+          bgcolor: "#fb923c",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.6,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 160,
+          left: 128,
+          width: 8,
+          height: 8,
+          bgcolor: "#c084fc",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.75,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 96,
+          left: "33.33%",
+          width: 4,
+          height: 4,
+          bgcolor: "#22d3ee",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.9,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 112,
+          right: "25%",
+          width: 8,
+          height: 8,
+          bgcolor: "#fbb6ce",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.65,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 240,
+          left: "25%",
+          width: 4,
+          height: 4,
+          bgcolor: "#60a5fa",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.8,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 48,
+          left: "50%",
+          width: 8,
+          height: 8,
+          bgcolor: "#4ade80",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.7,
+        }}
+      />
+      <Box
+        sx={{
+          position: "absolute",
+          top: 192,
+          right: "33.33%",
+          width: 4,
+          height: 4,
+          bgcolor: "#f87171",
+          borderRadius: "50%",
+          animation: "pulse 2s infinite",
+          opacity: 0.85,
+        }}
+      />
+    </Box>
+  );
+};
+
+export default MuiDecorativeStars;

--- a/client/components/signup-mui/MuiEducatorsSection.jsx
+++ b/client/components/signup-mui/MuiEducatorsSection.jsx
@@ -1,0 +1,250 @@
+import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+
+const MuiEducatorsSection = () => {
+  const educatorItems = [
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?w=500&h=280&fit=crop&crop=center"
+    },
+    { 
+      title: "The TaleTree Method", 
+      date: "Jun 30,2025",
+      isMethodCard: true
+    },
+  ];
+
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "18px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          TaleTree for educators
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      {/* 2 cards side by side */}
+      <Grid container spacing={4}>
+        {educatorItems.map((item, i) => (
+          <Grid item xs={12} md={6} key={i}>
+            <Card
+              sx={{
+                bgcolor: "white",
+                borderRadius: "16px",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+                overflow: "hidden",
+                transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+                },
+              }}
+            >
+              {/* Educational content image */}
+              <Box
+                sx={{
+                  width: "100%",
+                  height: 240,
+                  position: "relative",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {i === 0 ? (
+                  // First card - classroom image
+                  <Box
+                    sx={{
+                      width: "100%",
+                      height: "100%",
+                      backgroundImage: `url(${item.image})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                    }}
+                  />
+                ) : (
+                  // Second card - TaleTree Method diagram
+                  <Box
+                    sx={{
+                      width: "100%",
+                      height: "100%",
+                      background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%)",
+                      position: "relative",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {/* Central circular diagram */}
+                    <Box
+                      sx={{
+                        width: 160,
+                        height: 160,
+                        borderRadius: "50%",
+                        background: "linear-gradient(45deg, #f59e0b, #22c55e, #3b82f6, #ef4444)",
+                        position: "relative",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      {/* Inner circle */}
+                      <Box
+                        sx={{
+                          width: 120,
+                          height: 120,
+                          borderRadius: "50%",
+                          bgcolor: "#1e1b4b",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        {/* Tree symbol */}
+                        <Box
+                          sx={{
+                            width: 40,
+                            height: 60,
+                            position: "relative",
+                          }}
+                        >
+                          {/* Tree trunk */}
+                          <Box
+                            sx={{
+                              position: "absolute",
+                              bottom: 0,
+                              left: "50%",
+                              transform: "translateX(-50%)",
+                              width: 8,
+                              height: 20,
+                              bgcolor: "#a855f7",
+                              borderRadius: "2px",
+                            }}
+                          />
+                          {/* Tree crown */}
+                          <Box
+                            sx={{
+                              position: "absolute",
+                              top: 0,
+                              left: "50%",
+                              transform: "translateX(-50%)",
+                              width: 32,
+                              height: 32,
+                              bgcolor: "#22c55e",
+                              borderRadius: "50%",
+                            }}
+                          />
+                        </Box>
+                      </Box>
+                    </Box>
+
+                    {/* Method labels around the circle */}
+                    {[
+                      { text: "IMAGINE", color: "#a855f7", top: "10%", right: "15%" },
+                      { text: "REWARD", color: "#f59e0b", top: "25%", left: "8%" },
+                      { text: "PLAY", color: "#3b82f6", bottom: "25%", right: "12%" },
+                      { text: "REFLECT", color: "#ef4444", bottom: "35%", left: "5%" },
+                      { text: "CREATE", color: "#22c55e", bottom: "15%", right: "8%" },
+                      { text: "SHARE", color: "#ec4899", bottom: "10%", left: "15%" },
+                      { text: "STORE", color: "#06b6d4", bottom: "20%", right: "25%" },
+                    ].map((label, index) => (
+                      <Box
+                        key={index}
+                        sx={{
+                          position: "absolute",
+                          ...label,
+                          bgcolor: label.color,
+                          color: "white",
+                          px: 1.5,
+                          py: 0.5,
+                          borderRadius: "20px",
+                          fontSize: "10px",
+                          fontWeight: 600,
+                          textAlign: "center",
+                          minWidth: "60px",
+                        }}
+                      >
+                        {label.text}
+                      </Box>
+                    ))}
+
+                    {/* Small connecting elements */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: "30%",
+                        right: "30%",
+                        width: 6,
+                        height: 6,
+                        bgcolor: "#fbbf24",
+                        borderRadius: "50%",
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        bottom: "40%",
+                        left: "25%",
+                        width: 8,
+                        height: 8,
+                        bgcolor: "#34d399",
+                        borderRadius: "50%",
+                      }}
+                    />
+                  </Box>
+                )}
+              </Box>
+
+              <CardContent sx={{ p: 3 }}>
+                <Typography
+                  variant="body1"
+                  sx={{
+                    fontSize: "16px",
+                    fontWeight: 600,
+                    color: "#111827",
+                    mb: 1,
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {item.title}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: "12px",
+                    color: "#6b7280",
+                  }}
+                >
+                  {item.date}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiEducatorsSection;

--- a/client/components/signup-mui/MuiEducatorsSection.jsx
+++ b/client/components/signup-mui/MuiEducatorsSection.jsx
@@ -1,22 +1,38 @@
-import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+import {
+  Box,
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+} from "@mui/material";
 
 const MuiEducatorsSection = () => {
   const educatorItems = [
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?w=500&h=280&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?w=500&h=280&fit=crop&crop=center",
     },
-    { 
-      title: "The TaleTree Method", 
+    {
+      title: "The TaleTree Method",
       date: "Jun 30,2025",
-      isMethodCard: true
+      isMethodCard: true,
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{
@@ -89,7 +105,8 @@ const MuiEducatorsSection = () => {
                     sx={{
                       width: "100%",
                       height: "100%",
-                      background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%)",
+                      background:
+                        "linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%)",
                       position: "relative",
                       display: "flex",
                       alignItems: "center",
@@ -102,7 +119,8 @@ const MuiEducatorsSection = () => {
                         width: 160,
                         height: 160,
                         borderRadius: "50%",
-                        background: "linear-gradient(45deg, #f59e0b, #22c55e, #3b82f6, #ef4444)",
+                        background:
+                          "linear-gradient(45deg, #f59e0b, #22c55e, #3b82f6, #ef4444)",
                         position: "relative",
                         display: "flex",
                         alignItems: "center",
@@ -161,13 +179,48 @@ const MuiEducatorsSection = () => {
 
                     {/* Method labels around the circle */}
                     {[
-                      { text: "IMAGINE", color: "#a855f7", top: "10%", right: "15%" },
-                      { text: "REWARD", color: "#f59e0b", top: "25%", left: "8%" },
-                      { text: "PLAY", color: "#3b82f6", bottom: "25%", right: "12%" },
-                      { text: "REFLECT", color: "#ef4444", bottom: "35%", left: "5%" },
-                      { text: "CREATE", color: "#22c55e", bottom: "15%", right: "8%" },
-                      { text: "SHARE", color: "#ec4899", bottom: "10%", left: "15%" },
-                      { text: "STORE", color: "#06b6d4", bottom: "20%", right: "25%" },
+                      {
+                        text: "IMAGINE",
+                        color: "#a855f7",
+                        top: "10%",
+                        right: "15%",
+                      },
+                      {
+                        text: "REWARD",
+                        color: "#f59e0b",
+                        top: "25%",
+                        left: "8%",
+                      },
+                      {
+                        text: "PLAY",
+                        color: "#3b82f6",
+                        bottom: "25%",
+                        right: "12%",
+                      },
+                      {
+                        text: "REFLECT",
+                        color: "#ef4444",
+                        bottom: "35%",
+                        left: "5%",
+                      },
+                      {
+                        text: "CREATE",
+                        color: "#22c55e",
+                        bottom: "15%",
+                        right: "8%",
+                      },
+                      {
+                        text: "SHARE",
+                        color: "#ec4899",
+                        bottom: "10%",
+                        left: "15%",
+                      },
+                      {
+                        text: "STORE",
+                        color: "#06b6d4",
+                        bottom: "20%",
+                        right: "25%",
+                      },
                     ].map((label, index) => (
                       <Box
                         key={index}

--- a/client/components/signup-mui/MuiEducatorsSection.tsx
+++ b/client/components/signup-mui/MuiEducatorsSection.tsx
@@ -1,9 +1,14 @@
 import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
 
 const MuiEducatorsSection = () => {
+  const educatorItems = [
+    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025" },
+    { title: "The TaleTree Method", date: "Jun 22, 2025" },
+  ];
+
   return (
-    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
         <Typography
           variant="h5"
           sx={{
@@ -31,90 +36,96 @@ const MuiEducatorsSection = () => {
         </Button>
       </Box>
 
-      <Grid container spacing={3}>
-        <Grid item xs={12} md={6}>
-          <Card
-            sx={{
-              bgcolor: "#f3f4f6",
-              border: "none",
-              boxShadow: "none",
-              borderRadius: "8px",
-            }}
-          >
-            <CardContent sx={{ p: 3 }}>
+      {/* 2 cards side by side */}
+      <Grid container spacing={4}>
+        {educatorItems.map((item, i) => (
+          <Grid item xs={12} md={6} key={i}>
+            <Card
+              sx={{
+                bgcolor: "white",
+                borderRadius: "12px",
+                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+                overflow: "hidden",
+                transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
+                },
+              }}
+            >
+              {/* Educational content image */}
               <Box
                 sx={{
                   width: "100%",
-                  height: 160,
-                  bgcolor: "#e5e7eb",
-                  borderRadius: "6px",
-                  mb: 2,
-                }}
-              />
-              <Typography
-                variant="body2"
-                sx={{
-                  fontSize: "14px",
-                  color: "#374151",
-                  mb: 1,
+                  height: 200,
+                  bgcolor: i === 0 ? "#eff6ff" : "#f0f9ff",
+                  position: "relative",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
                 }}
               >
-                Learn about what we offer
-              </Typography>
-              <Typography
-                variant="caption"
-                sx={{
-                  fontSize: "12px",
-                  color: "#9ca3af",
-                }}
-              >
-                Jan 24, 2024
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
+                {/* Educational icon/illustration */}
+                <Box
+                  sx={{
+                    width: 80,
+                    height: 80,
+                    borderRadius: "50%",
+                    bgcolor: i === 0 ? "#3b82f6" : "#06b6d4",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  {/* Book/Education icon representation */}
+                  <Box
+                    sx={{
+                      width: 40,
+                      height: 30,
+                      bgcolor: "white",
+                      borderRadius: "4px",
+                      position: "relative",
+                      "&::after": {
+                        content: '""',
+                        position: "absolute",
+                        top: "50%",
+                        left: "50%",
+                        transform: "translate(-50%, -50%)",
+                        width: 2,
+                        height: 20,
+                        bgcolor: i === 0 ? "#3b82f6" : "#06b6d4",
+                      },
+                    }}
+                  />
+                </Box>
+              </Box>
 
-        <Grid item xs={12} md={6}>
-          <Card
-            sx={{
-              bgcolor: "#f3f4f6",
-              border: "none",
-              boxShadow: "none",
-              borderRadius: "8px",
-            }}
-          >
-            <CardContent sx={{ p: 3 }}>
-              <Box
-                sx={{
-                  width: "100%",
-                  height: 160,
-                  bgcolor: "#e5e7eb",
-                  borderRadius: "6px",
-                  mb: 2,
-                }}
-              />
-              <Typography
-                variant="body2"
-                sx={{
-                  fontSize: "14px",
-                  color: "#374151",
-                  mb: 1,
-                }}
-              >
-                The TaleTree Method
-              </Typography>
-              <Typography
-                variant="caption"
-                sx={{
-                  fontSize: "12px",
-                  color: "#9ca3af",
-                }}
-              >
-                Jan 24, 2024
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
+              <CardContent sx={{ p: 3 }}>
+                <Typography
+                  variant="body1"
+                  sx={{
+                    fontSize: "16px",
+                    fontWeight: 600,
+                    color: "#111827",
+                    mb: 1,
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {item.title}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: "12px",
+                    color: "#6b7280",
+                  }}
+                >
+                  {item.date}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
       </Grid>
     </Container>
   );

--- a/client/components/signup-mui/MuiEducatorsSection.tsx
+++ b/client/components/signup-mui/MuiEducatorsSection.tsx
@@ -1,0 +1,123 @@
+import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+
+const MuiEducatorsSection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "20px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          TaleTree for Educators
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <Card
+            sx={{
+              bgcolor: "#f3f4f6",
+              border: "none",
+              boxShadow: "none",
+              borderRadius: "8px",
+            }}
+          >
+            <CardContent sx={{ p: 3 }}>
+              <Box
+                sx={{
+                  width: "100%",
+                  height: 160,
+                  bgcolor: "#e5e7eb",
+                  borderRadius: "6px",
+                  mb: 2,
+                }}
+              />
+              <Typography
+                variant="body2"
+                sx={{
+                  fontSize: "14px",
+                  color: "#374151",
+                  mb: 1,
+                }}
+              >
+                Learn about what we offer
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#9ca3af",
+                }}
+              >
+                Jan 24, 2024
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Card
+            sx={{
+              bgcolor: "#f3f4f6",
+              border: "none",
+              boxShadow: "none",
+              borderRadius: "8px",
+            }}
+          >
+            <CardContent sx={{ p: 3 }}>
+              <Box
+                sx={{
+                  width: "100%",
+                  height: 160,
+                  bgcolor: "#e5e7eb",
+                  borderRadius: "6px",
+                  mb: 2,
+                }}
+              />
+              <Typography
+                variant="body2"
+                sx={{
+                  fontSize: "14px",
+                  color: "#374151",
+                  mb: 1,
+                }}
+              >
+                The TaleTree Method
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#9ca3af",
+                }}
+              >
+                Jan 24, 2024
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiEducatorsSection;

--- a/client/components/signup-mui/MuiEducatorsSection.tsx
+++ b/client/components/signup-mui/MuiEducatorsSection.tsx
@@ -2,8 +2,16 @@ import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mu
 
 const MuiEducatorsSection = () => {
   const educatorItems = [
-    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025" },
-    { title: "The TaleTree Method", date: "Jun 22, 2025" },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?w=500&h=280&fit=crop&crop=center"
+    },
+    { 
+      title: "The TaleTree Method", 
+      date: "Jun 30,2025",
+      isMethodCard: true
+    },
   ];
 
   return (
@@ -12,12 +20,12 @@ const MuiEducatorsSection = () => {
         <Typography
           variant="h5"
           sx={{
-            fontSize: "20px",
+            fontSize: "18px",
             fontWeight: 600,
             color: "#111827",
           }}
         >
-          TaleTree for Educators
+          TaleTree for educators
         </Typography>
         <Button
           sx={{
@@ -43,13 +51,13 @@ const MuiEducatorsSection = () => {
             <Card
               sx={{
                 bgcolor: "white",
-                borderRadius: "12px",
-                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+                borderRadius: "16px",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
                 overflow: "hidden",
                 transition: "transform 0.2s ease, box-shadow 0.2s ease",
                 "&:hover": {
                   transform: "translateY(-2px)",
-                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
+                  boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
                 },
               }}
             >
@@ -57,47 +65,155 @@ const MuiEducatorsSection = () => {
               <Box
                 sx={{
                   width: "100%",
-                  height: 200,
-                  bgcolor: i === 0 ? "#eff6ff" : "#f0f9ff",
+                  height: 240,
                   position: "relative",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
                 }}
               >
-                {/* Educational icon/illustration */}
-                <Box
-                  sx={{
-                    width: 80,
-                    height: 80,
-                    borderRadius: "50%",
-                    bgcolor: i === 0 ? "#3b82f6" : "#06b6d4",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  {/* Book/Education icon representation */}
+                {i === 0 ? (
+                  // First card - classroom image
                   <Box
                     sx={{
-                      width: 40,
-                      height: 30,
-                      bgcolor: "white",
-                      borderRadius: "4px",
-                      position: "relative",
-                      "&::after": {
-                        content: '""',
-                        position: "absolute",
-                        top: "50%",
-                        left: "50%",
-                        transform: "translate(-50%, -50%)",
-                        width: 2,
-                        height: 20,
-                        bgcolor: i === 0 ? "#3b82f6" : "#06b6d4",
-                      },
+                      width: "100%",
+                      height: "100%",
+                      backgroundImage: `url(${item.image})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
                     }}
                   />
-                </Box>
+                ) : (
+                  // Second card - TaleTree Method diagram
+                  <Box
+                    sx={{
+                      width: "100%",
+                      height: "100%",
+                      background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%)",
+                      position: "relative",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {/* Central circular diagram */}
+                    <Box
+                      sx={{
+                        width: 160,
+                        height: 160,
+                        borderRadius: "50%",
+                        background: "linear-gradient(45deg, #f59e0b, #22c55e, #3b82f6, #ef4444)",
+                        position: "relative",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      {/* Inner circle */}
+                      <Box
+                        sx={{
+                          width: 120,
+                          height: 120,
+                          borderRadius: "50%",
+                          bgcolor: "#1e1b4b",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        {/* Tree symbol */}
+                        <Box
+                          sx={{
+                            width: 40,
+                            height: 60,
+                            position: "relative",
+                          }}
+                        >
+                          {/* Tree trunk */}
+                          <Box
+                            sx={{
+                              position: "absolute",
+                              bottom: 0,
+                              left: "50%",
+                              transform: "translateX(-50%)",
+                              width: 8,
+                              height: 20,
+                              bgcolor: "#a855f7",
+                              borderRadius: "2px",
+                            }}
+                          />
+                          {/* Tree crown */}
+                          <Box
+                            sx={{
+                              position: "absolute",
+                              top: 0,
+                              left: "50%",
+                              transform: "translateX(-50%)",
+                              width: 32,
+                              height: 32,
+                              bgcolor: "#22c55e",
+                              borderRadius: "50%",
+                            }}
+                          />
+                        </Box>
+                      </Box>
+                    </Box>
+
+                    {/* Method labels around the circle */}
+                    {[
+                      { text: "IMAGINE", color: "#a855f7", top: "10%", right: "15%" },
+                      { text: "REWARD", color: "#f59e0b", top: "25%", left: "8%" },
+                      { text: "PLAY", color: "#3b82f6", bottom: "25%", right: "12%" },
+                      { text: "REFLECT", color: "#ef4444", bottom: "35%", left: "5%" },
+                      { text: "CREATE", color: "#22c55e", bottom: "15%", right: "8%" },
+                      { text: "SHARE", color: "#ec4899", bottom: "10%", left: "15%" },
+                      { text: "STORE", color: "#06b6d4", bottom: "20%", right: "25%" },
+                    ].map((label, index) => (
+                      <Box
+                        key={index}
+                        sx={{
+                          position: "absolute",
+                          ...label,
+                          bgcolor: label.color,
+                          color: "white",
+                          px: 1.5,
+                          py: 0.5,
+                          borderRadius: "20px",
+                          fontSize: "10px",
+                          fontWeight: 600,
+                          textAlign: "center",
+                          minWidth: "60px",
+                        }}
+                      >
+                        {label.text}
+                      </Box>
+                    ))}
+
+                    {/* Small connecting elements */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: "30%",
+                        right: "30%",
+                        width: 6,
+                        height: 6,
+                        bgcolor: "#fbbf24",
+                        borderRadius: "50%",
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        bottom: "40%",
+                        left: "25%",
+                        width: 8,
+                        height: 8,
+                        bgcolor: "#34d399",
+                        borderRadius: "50%",
+                      }}
+                    />
+                  </Box>
+                )}
               </Box>
 
               <CardContent sx={{ p: 3 }}>

--- a/client/components/signup-mui/MuiEducatorsSection.tsx
+++ b/client/components/signup-mui/MuiEducatorsSection.tsx
@@ -1,22 +1,38 @@
-import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+import {
+  Box,
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+} from "@mui/material";
 
 const MuiEducatorsSection = () => {
   const educatorItems = [
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?w=500&h=280&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?w=500&h=280&fit=crop&crop=center",
     },
-    { 
-      title: "The TaleTree Method", 
+    {
+      title: "The TaleTree Method",
       date: "Jun 30,2025",
-      isMethodCard: true
+      isMethodCard: true,
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{
@@ -89,7 +105,8 @@ const MuiEducatorsSection = () => {
                     sx={{
                       width: "100%",
                       height: "100%",
-                      background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%)",
+                      background:
+                        "linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%)",
                       position: "relative",
                       display: "flex",
                       alignItems: "center",
@@ -102,7 +119,8 @@ const MuiEducatorsSection = () => {
                         width: 160,
                         height: 160,
                         borderRadius: "50%",
-                        background: "linear-gradient(45deg, #f59e0b, #22c55e, #3b82f6, #ef4444)",
+                        background:
+                          "linear-gradient(45deg, #f59e0b, #22c55e, #3b82f6, #ef4444)",
                         position: "relative",
                         display: "flex",
                         alignItems: "center",
@@ -161,13 +179,48 @@ const MuiEducatorsSection = () => {
 
                     {/* Method labels around the circle */}
                     {[
-                      { text: "IMAGINE", color: "#a855f7", top: "10%", right: "15%" },
-                      { text: "REWARD", color: "#f59e0b", top: "25%", left: "8%" },
-                      { text: "PLAY", color: "#3b82f6", bottom: "25%", right: "12%" },
-                      { text: "REFLECT", color: "#ef4444", bottom: "35%", left: "5%" },
-                      { text: "CREATE", color: "#22c55e", bottom: "15%", right: "8%" },
-                      { text: "SHARE", color: "#ec4899", bottom: "10%", left: "15%" },
-                      { text: "STORE", color: "#06b6d4", bottom: "20%", right: "25%" },
+                      {
+                        text: "IMAGINE",
+                        color: "#a855f7",
+                        top: "10%",
+                        right: "15%",
+                      },
+                      {
+                        text: "REWARD",
+                        color: "#f59e0b",
+                        top: "25%",
+                        left: "8%",
+                      },
+                      {
+                        text: "PLAY",
+                        color: "#3b82f6",
+                        bottom: "25%",
+                        right: "12%",
+                      },
+                      {
+                        text: "REFLECT",
+                        color: "#ef4444",
+                        bottom: "35%",
+                        left: "5%",
+                      },
+                      {
+                        text: "CREATE",
+                        color: "#22c55e",
+                        bottom: "15%",
+                        right: "8%",
+                      },
+                      {
+                        text: "SHARE",
+                        color: "#ec4899",
+                        bottom: "10%",
+                        left: "15%",
+                      },
+                      {
+                        text: "STORE",
+                        color: "#06b6d4",
+                        bottom: "20%",
+                        right: "25%",
+                      },
                     ].map((label, index) => (
                       <Box
                         key={index}

--- a/client/components/signup-mui/MuiExpertsSection.jsx
+++ b/client/components/signup-mui/MuiExpertsSection.jsx
@@ -1,0 +1,111 @@
+import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+
+const MuiExpertsSection = () => {
+  const expertItems = [
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=240&fit=crop&crop=face"
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1497366216548-37526070297c?w=400&h=240&fit=crop&crop=center"
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=400&h=240&fit=crop&crop=center"
+    },
+  ];
+
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "18px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          Experts and brands
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      {/* 3 equal cards for experts and brands */}
+      <Grid container spacing={4}>
+        {expertItems.map((item, i) => (
+          <Grid item xs={12} md={4} key={i}>
+            <Card
+              sx={{
+                bgcolor: "white",
+                borderRadius: "16px",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+                overflow: "hidden",
+                transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+                },
+              }}
+            >
+              {/* Professional/Expert image */}
+              <Box
+                sx={{
+                  width: "100%",
+                  height: 200,
+                  backgroundImage: `url(${item.image})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                }}
+              />
+
+              <CardContent sx={{ p: 3 }}>
+                <Typography
+                  variant="body1"
+                  sx={{
+                    fontSize: "16px",
+                    fontWeight: 600,
+                    color: "#111827",
+                    mb: 1,
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {item.title}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: "12px",
+                    color: "#6b7280",
+                  }}
+                >
+                  {item.date}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiExpertsSection;

--- a/client/components/signup-mui/MuiExpertsSection.jsx
+++ b/client/components/signup-mui/MuiExpertsSection.jsx
@@ -1,27 +1,45 @@
-import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+import {
+  Box,
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+} from "@mui/material";
 
 const MuiExpertsSection = () => {
   const expertItems = [
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=240&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=240&fit=crop&crop=face",
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1497366216548-37526070297c?w=400&h=240&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1497366216548-37526070297c?w=400&h=240&fit=crop&crop=center",
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=400&h=240&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=400&h=240&fit=crop&crop=center",
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{

--- a/client/components/signup-mui/MuiExpertsSection.tsx
+++ b/client/components/signup-mui/MuiExpertsSection.tsx
@@ -2,9 +2,21 @@ import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mu
 
 const MuiExpertsSection = () => {
   const expertItems = [
-    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025", category: "Expert Opinion" },
-    { title: "Consectetur adipiscing elit", date: "Jun 22, 2025", category: "Brand Partnership" },
-    { title: "Sed do eiusmod tempor", date: "Jun 21, 2025", category: "Research Study" },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=240&fit=crop&crop=face"
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1497366216548-37526070297c?w=400&h=240&fit=crop&crop=center"
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=400&h=240&fit=crop&crop=center"
+    },
   ];
 
   return (
@@ -13,12 +25,12 @@ const MuiExpertsSection = () => {
         <Typography
           variant="h5"
           sx={{
-            fontSize: "20px",
+            fontSize: "18px",
             fontWeight: 600,
             color: "#111827",
           }}
         >
-          Experts and Brands
+          Experts and brands
         </Typography>
         <Button
           sx={{
@@ -37,71 +49,33 @@ const MuiExpertsSection = () => {
         </Button>
       </Box>
 
-      {/* 3 cards for experts and brands */}
+      {/* 3 equal cards for experts and brands */}
       <Grid container spacing={4}>
         {expertItems.map((item, i) => (
           <Grid item xs={12} md={4} key={i}>
             <Card
               sx={{
                 bgcolor: "white",
-                borderRadius: "12px",
-                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+                borderRadius: "16px",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
                 overflow: "hidden",
                 transition: "transform 0.2s ease, box-shadow 0.2s ease",
                 "&:hover": {
                   transform: "translateY(-2px)",
-                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
+                  boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
                 },
               }}
             >
-              {/* Expert/Brand image with professional look */}
+              {/* Professional/Expert image */}
               <Box
                 sx={{
                   width: "100%",
-                  height: 160,
-                  bgcolor: i === 0 ? "#f8fafc" : i === 1 ? "#fefbf3" : "#f0fdf4",
-                  position: "relative",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
+                  height: 200,
+                  backgroundImage: `url(${item.image})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
                 }}
-              >
-                {/* Professional/Business icon representation */}
-                <Box
-                  sx={{
-                    width: 60,
-                    height: 60,
-                    borderRadius: "12px",
-                    bgcolor: i === 0 ? "#64748b" : i === 1 ? "#f59e0b" : "#10b981",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    position: "relative",
-                  }}
-                >
-                  {/* Professional icon (briefcase/building representation) */}
-                  <Box
-                    sx={{
-                      width: 30,
-                      height: 20,
-                      bgcolor: "white",
-                      borderRadius: "4px",
-                      position: "relative",
-                      "&::before": {
-                        content: '""',
-                        position: "absolute",
-                        top: -5,
-                        left: "50%",
-                        transform: "translateX(-50%)",
-                        width: 20,
-                        height: 8,
-                        bgcolor: "white",
-                        borderRadius: "4px 4px 0 0",
-                      },
-                    }}
-                  />
-                </Box>
-              </Box>
+              />
 
               <CardContent sx={{ p: 3 }}>
                 <Typography

--- a/client/components/signup-mui/MuiExpertsSection.tsx
+++ b/client/components/signup-mui/MuiExpertsSection.tsx
@@ -1,0 +1,83 @@
+import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+
+const MuiExpertsSection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "20px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          Experts and Brands
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      <Grid container spacing={3}>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Grid item xs={12} md={4} key={i}>
+            <Card
+              sx={{
+                bgcolor: "#f3f4f6",
+                border: "none",
+                boxShadow: "none",
+                borderRadius: "8px",
+              }}
+            >
+              <CardContent sx={{ p: 3 }}>
+                <Box
+                  sx={{
+                    width: "100%",
+                    height: 128,
+                    bgcolor: "#e5e7eb",
+                    borderRadius: "6px",
+                    mb: 2,
+                  }}
+                />
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "14px",
+                    color: "#374151",
+                    mb: 1,
+                  }}
+                >
+                  Expert opinion piece
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: "12px",
+                    color: "#9ca3af",
+                  }}
+                >
+                  Jan 24, 2024
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiExpertsSection;

--- a/client/components/signup-mui/MuiExpertsSection.tsx
+++ b/client/components/signup-mui/MuiExpertsSection.tsx
@@ -1,9 +1,15 @@
 import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
 
 const MuiExpertsSection = () => {
+  const expertItems = [
+    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025", category: "Expert Opinion" },
+    { title: "Consectetur adipiscing elit", date: "Jun 22, 2025", category: "Brand Partnership" },
+    { title: "Sed do eiusmod tempor", date: "Jun 21, 2025", category: "Research Study" },
+  ];
+
   return (
-    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
         <Typography
           variant="h5"
           sx={{
@@ -31,45 +37,93 @@ const MuiExpertsSection = () => {
         </Button>
       </Box>
 
-      <Grid container spacing={3}>
-        {Array.from({ length: 3 }).map((_, i) => (
+      {/* 3 cards for experts and brands */}
+      <Grid container spacing={4}>
+        {expertItems.map((item, i) => (
           <Grid item xs={12} md={4} key={i}>
             <Card
               sx={{
-                bgcolor: "#f3f4f6",
-                border: "none",
-                boxShadow: "none",
-                borderRadius: "8px",
+                bgcolor: "white",
+                borderRadius: "12px",
+                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+                overflow: "hidden",
+                transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
+                },
               }}
             >
-              <CardContent sx={{ p: 3 }}>
+              {/* Expert/Brand image with professional look */}
+              <Box
+                sx={{
+                  width: "100%",
+                  height: 160,
+                  bgcolor: i === 0 ? "#f8fafc" : i === 1 ? "#fefbf3" : "#f0fdf4",
+                  position: "relative",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {/* Professional/Business icon representation */}
                 <Box
                   sx={{
-                    width: "100%",
-                    height: 128,
-                    bgcolor: "#e5e7eb",
-                    borderRadius: "6px",
-                    mb: 2,
-                  }}
-                />
-                <Typography
-                  variant="body2"
-                  sx={{
-                    fontSize: "14px",
-                    color: "#374151",
-                    mb: 1,
+                    width: 60,
+                    height: 60,
+                    borderRadius: "12px",
+                    bgcolor: i === 0 ? "#64748b" : i === 1 ? "#f59e0b" : "#10b981",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    position: "relative",
                   }}
                 >
-                  Expert opinion piece
+                  {/* Professional icon (briefcase/building representation) */}
+                  <Box
+                    sx={{
+                      width: 30,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "4px",
+                      position: "relative",
+                      "&::before": {
+                        content: '""',
+                        position: "absolute",
+                        top: -5,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        width: 20,
+                        height: 8,
+                        bgcolor: "white",
+                        borderRadius: "4px 4px 0 0",
+                      },
+                    }}
+                  />
+                </Box>
+              </Box>
+
+              <CardContent sx={{ p: 3 }}>
+                <Typography
+                  variant="body1"
+                  sx={{
+                    fontSize: "16px",
+                    fontWeight: 600,
+                    color: "#111827",
+                    mb: 1,
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {item.title}
                 </Typography>
                 <Typography
                   variant="caption"
                   sx={{
                     fontSize: "12px",
-                    color: "#9ca3af",
+                    color: "#6b7280",
                   }}
                 >
-                  Jan 24, 2024
+                  {item.date}
                 </Typography>
               </CardContent>
             </Card>

--- a/client/components/signup-mui/MuiExpertsSection.tsx
+++ b/client/components/signup-mui/MuiExpertsSection.tsx
@@ -1,27 +1,45 @@
-import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+import {
+  Box,
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+} from "@mui/material";
 
 const MuiExpertsSection = () => {
   const expertItems = [
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=240&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=240&fit=crop&crop=face",
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1497366216548-37526070297c?w=400&h=240&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1497366216548-37526070297c?w=400&h=240&fit=crop&crop=center",
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
+    {
+      title: "Lorem ipsum dolor sit amet",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=400&h=240&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=400&h=240&fit=crop&crop=center",
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{

--- a/client/components/signup-mui/MuiHeaderActions.jsx
+++ b/client/components/signup-mui/MuiHeaderActions.jsx
@@ -142,7 +142,8 @@ export function MuiHeaderActions() {
           sx={{
             "& .MuiPaper-root": {
               borderRadius: "16px",
-              boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+              boxShadow:
+                "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
               border: "1px solid #f3f4f6",
               minWidth: "140px",
               mt: 1,

--- a/client/components/signup-mui/MuiHeaderActions.jsx
+++ b/client/components/signup-mui/MuiHeaderActions.jsx
@@ -1,0 +1,241 @@
+import { useState } from "react";
+import {
+  Box,
+  IconButton,
+  TextField,
+  Button,
+  Menu,
+  MenuItem,
+  Avatar,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import { Search, Person } from "@mui/icons-material";
+
+export function MuiHeaderActions() {
+  const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const isLoginMenuOpen = Boolean(anchorEl);
+
+  const handleSearchClick = () => {
+    setIsSearchExpanded(!isSearchExpanded);
+  };
+
+  const handleLoginClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleLoginClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        top: 24,
+        right: 24,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+      }}
+    >
+      {/* Search Component */}
+      <Box sx={{ position: "relative" }}>
+        {!isSearchExpanded ? (
+          <IconButton
+            onClick={handleSearchClick}
+            sx={{
+              width: 40,
+              height: 40,
+              border: "1px solid rgba(255, 255, 255, 0.4)",
+              borderRadius: "50%",
+              color: "white",
+              "&:hover": {
+                bgcolor: "rgba(255, 255, 255, 0.1)",
+              },
+              transition: "all 0.3s ease",
+            }}
+          >
+            <Search sx={{ width: 20, height: 20 }} />
+          </IconButton>
+        ) : (
+          <Box
+            sx={{
+              bgcolor: "transparent",
+              backdropFilter: "blur(8px)",
+              border: "1px solid rgba(255, 255, 255, 0.4)",
+              borderRadius: "25px",
+              px: 2,
+              py: 1,
+              minWidth: "240px",
+              transition: "all 0.3s ease",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Search sx={{ width: 16, height: 16, color: "white" }} />
+              <TextField
+                placeholder="Search TaleTree"
+                variant="standard"
+                fullWidth
+                autoFocus
+                onBlur={() => setIsSearchExpanded(false)}
+                sx={{
+                  "& .MuiInput-underline:before": {
+                    borderBottom: "none",
+                  },
+                  "& .MuiInput-underline:after": {
+                    borderBottom: "none",
+                  },
+                  "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+                    borderBottom: "none",
+                  },
+                  "& .MuiInputBase-input": {
+                    color: "white",
+                    fontSize: "14px",
+                    padding: 0,
+                    "&::placeholder": {
+                      color: "rgba(255, 255, 255, 0.7)",
+                      opacity: 1,
+                    },
+                  },
+                }}
+              />
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {/* Login Component */}
+      <Box sx={{ position: "relative" }}>
+        <Button
+          onClick={handleLoginClick}
+          sx={{
+            border: "1px solid rgba(255, 255, 255, 0.4)",
+            color: "white",
+            px: 2,
+            py: 1,
+            borderRadius: "25px",
+            fontWeight: 500,
+            fontSize: "14px",
+            textTransform: "none",
+            "&:hover": {
+              bgcolor: "white",
+              color: "#374151",
+            },
+            transition: "all 0.3s ease",
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
+          <Person sx={{ width: 16, height: 16 }} />
+          Login
+        </Button>
+
+        {/* Login Dropdown Menu */}
+        <Menu
+          anchorEl={anchorEl}
+          open={isLoginMenuOpen}
+          onClose={handleLoginClose}
+          sx={{
+            "& .MuiPaper-root": {
+              borderRadius: "16px",
+              boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+              border: "1px solid #f3f4f6",
+              minWidth: "140px",
+              mt: 1,
+            },
+          }}
+          transformOrigin={{ horizontal: "right", vertical: "top" }}
+          anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+        >
+          <MenuItem
+            onClick={handleLoginClose}
+            sx={{
+              px: 2,
+              py: 1.5,
+              "&:hover": {
+                bgcolor: "#f9fafb",
+              },
+              transition: "background-color 0.2s ease",
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 32 }}>
+              <Avatar
+                src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F8ade38e9e3ed4481823af4c44b90eec8?format=webp&width=800"
+                alt="Kids"
+                sx={{ width: 24, height: 24 }}
+              />
+            </ListItemIcon>
+            <ListItemText
+              primary="Kids"
+              primaryTypographyProps={{
+                fontSize: "14px",
+                fontWeight: 500,
+                color: "#374151",
+              }}
+            />
+          </MenuItem>
+
+          <MenuItem
+            onClick={handleLoginClose}
+            sx={{
+              px: 2,
+              py: 1.5,
+              "&:hover": {
+                bgcolor: "#f9fafb",
+              },
+              transition: "background-color 0.2s ease",
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 32 }}>
+              <Avatar
+                src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F70906b39ddd5462b8740ab078244aace?format=webp&width=800"
+                alt="Parent"
+                sx={{ width: 24, height: 24 }}
+              />
+            </ListItemIcon>
+            <ListItemText
+              primary="Guardians"
+              primaryTypographyProps={{
+                fontSize: "14px",
+                fontWeight: 500,
+                color: "#374151",
+              }}
+            />
+          </MenuItem>
+
+          <MenuItem
+            onClick={handleLoginClose}
+            sx={{
+              px: 2,
+              py: 1.5,
+              "&:hover": {
+                bgcolor: "#f9fafb",
+              },
+              transition: "background-color 0.2s ease",
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 32 }}>
+              <Avatar
+                src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F79afaa309c38474ba6bc9b0f00dbac56?format=webp&width=800"
+                alt="Educator"
+                sx={{ width: 24, height: 24 }}
+              />
+            </ListItemIcon>
+            <ListItemText
+              primary="Educator"
+              primaryTypographyProps={{
+                fontSize: "14px",
+                fontWeight: 500,
+                color: "#374151",
+              }}
+            />
+          </MenuItem>
+        </Menu>
+      </Box>
+    </Box>
+  );
+}

--- a/client/components/signup-mui/MuiHeaderActions.tsx
+++ b/client/components/signup-mui/MuiHeaderActions.tsx
@@ -1,0 +1,241 @@
+import { useState } from "react";
+import {
+  Box,
+  IconButton,
+  TextField,
+  Button,
+  Menu,
+  MenuItem,
+  Avatar,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import { Search, Person } from "@mui/icons-material";
+
+export function MuiHeaderActions() {
+  const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const isLoginMenuOpen = Boolean(anchorEl);
+
+  const handleSearchClick = () => {
+    setIsSearchExpanded(!isSearchExpanded);
+  };
+
+  const handleLoginClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleLoginClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        top: 24,
+        right: 24,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+      }}
+    >
+      {/* Search Component */}
+      <Box sx={{ position: "relative" }}>
+        {!isSearchExpanded ? (
+          <IconButton
+            onClick={handleSearchClick}
+            sx={{
+              width: 40,
+              height: 40,
+              border: "1px solid rgba(255, 255, 255, 0.4)",
+              borderRadius: "50%",
+              color: "white",
+              "&:hover": {
+                bgcolor: "rgba(255, 255, 255, 0.1)",
+              },
+              transition: "all 0.3s ease",
+            }}
+          >
+            <Search sx={{ width: 20, height: 20 }} />
+          </IconButton>
+        ) : (
+          <Box
+            sx={{
+              bgcolor: "transparent",
+              backdropFilter: "blur(8px)",
+              border: "1px solid rgba(255, 255, 255, 0.4)",
+              borderRadius: "25px",
+              px: 2,
+              py: 1,
+              minWidth: "240px",
+              transition: "all 0.3s ease",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Search sx={{ width: 16, height: 16, color: "white" }} />
+              <TextField
+                placeholder="Search TaleTree"
+                variant="standard"
+                fullWidth
+                autoFocus
+                onBlur={() => setIsSearchExpanded(false)}
+                sx={{
+                  "& .MuiInput-underline:before": {
+                    borderBottom: "none",
+                  },
+                  "& .MuiInput-underline:after": {
+                    borderBottom: "none",
+                  },
+                  "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+                    borderBottom: "none",
+                  },
+                  "& .MuiInputBase-input": {
+                    color: "white",
+                    fontSize: "14px",
+                    padding: 0,
+                    "&::placeholder": {
+                      color: "rgba(255, 255, 255, 0.7)",
+                      opacity: 1,
+                    },
+                  },
+                }}
+              />
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {/* Login Component */}
+      <Box sx={{ position: "relative" }}>
+        <Button
+          onClick={handleLoginClick}
+          sx={{
+            border: "1px solid rgba(255, 255, 255, 0.4)",
+            color: "white",
+            px: 2,
+            py: 1,
+            borderRadius: "25px",
+            fontWeight: 500,
+            fontSize: "14px",
+            textTransform: "none",
+            "&:hover": {
+              bgcolor: "white",
+              color: "#374151",
+            },
+            transition: "all 0.3s ease",
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
+          <Person sx={{ width: 16, height: 16 }} />
+          Login
+        </Button>
+
+        {/* Login Dropdown Menu */}
+        <Menu
+          anchorEl={anchorEl}
+          open={isLoginMenuOpen}
+          onClose={handleLoginClose}
+          sx={{
+            "& .MuiPaper-root": {
+              borderRadius: "16px",
+              boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+              border: "1px solid #f3f4f6",
+              minWidth: "140px",
+              mt: 1,
+            },
+          }}
+          transformOrigin={{ horizontal: "right", vertical: "top" }}
+          anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+        >
+          <MenuItem
+            onClick={handleLoginClose}
+            sx={{
+              px: 2,
+              py: 1.5,
+              "&:hover": {
+                bgcolor: "#f9fafb",
+              },
+              transition: "background-color 0.2s ease",
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 32 }}>
+              <Avatar
+                src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F8ade38e9e3ed4481823af4c44b90eec8?format=webp&width=800"
+                alt="Kids"
+                sx={{ width: 24, height: 24 }}
+              />
+            </ListItemIcon>
+            <ListItemText
+              primary="Kids"
+              primaryTypographyProps={{
+                fontSize: "14px",
+                fontWeight: 500,
+                color: "#374151",
+              }}
+            />
+          </MenuItem>
+
+          <MenuItem
+            onClick={handleLoginClose}
+            sx={{
+              px: 2,
+              py: 1.5,
+              "&:hover": {
+                bgcolor: "#f9fafb",
+              },
+              transition: "background-color 0.2s ease",
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 32 }}>
+              <Avatar
+                src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F70906b39ddd5462b8740ab078244aace?format=webp&width=800"
+                alt="Parent"
+                sx={{ width: 24, height: 24 }}
+              />
+            </ListItemIcon>
+            <ListItemText
+              primary="Guardians"
+              primaryTypographyProps={{
+                fontSize: "14px",
+                fontWeight: 500,
+                color: "#374151",
+              }}
+            />
+          </MenuItem>
+
+          <MenuItem
+            onClick={handleLoginClose}
+            sx={{
+              px: 2,
+              py: 1.5,
+              "&:hover": {
+                bgcolor: "#f9fafb",
+              },
+              transition: "background-color 0.2s ease",
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 32 }}>
+              <Avatar
+                src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F79afaa309c38474ba6bc9b0f00dbac56?format=webp&width=800"
+                alt="Educator"
+                sx={{ width: 24, height: 24 }}
+              />
+            </ListItemIcon>
+            <ListItemText
+              primary="Educator"
+              primaryTypographyProps={{
+                fontSize: "14px",
+                fontWeight: 500,
+                color: "#374151",
+              }}
+            />
+          </MenuItem>
+        </Menu>
+      </Box>
+    </Box>
+  );
+}

--- a/client/components/signup-mui/MuiHeroSection.jsx
+++ b/client/components/signup-mui/MuiHeroSection.jsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { Box } from "@mui/material";
+import { MuiSignupChatContainer } from "./MuiSignupChatContainer";
+import { MuiSignupChatInput } from "./MuiSignupChatInput";
+import { MuiHeaderActions } from "./MuiHeaderActions";
+import { MuiSignupDualSidebar } from "./MuiSignupDualSidebar";
+
+const MuiHeroSection = () => {
+  const [chatMessages, setChatMessages] = useState([
+    {
+      id: "1",
+      type: "text",
+      sender: "AI",
+      content:
+        "It's time to start. Share the beautiful, magical stories and stories.",
+      timestamp: new Date(),
+    },
+  ]);
+
+  const handleSendMessage = (message) => {
+    // Add user message
+    const userMessage = {
+      id: Date.now().toString(),
+      type: "text",
+      sender: "Kid",
+      content: message,
+      timestamp: new Date(),
+    };
+    setChatMessages((prev) => [...prev, userMessage]);
+
+    // Simulate AI response after a delay
+    setTimeout(() => {
+      const aiResponse = {
+        id: (Date.now() + 1).toString(),
+        type: "text",
+        sender: "AI",
+        content: `Thanks for sharing: "${message}". Let's explore this together!`,
+        timestamp: new Date(),
+      };
+      setChatMessages((prev) => [...prev, aiResponse]);
+    }, 1500);
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        height: "100vh",
+        width: "100%",
+        overflow: "hidden",
+      }}
+    >
+      {/* Background Image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
+          backgroundPosition: "center center",
+          backgroundSize: "cover",
+          backgroundRepeat: "no-repeat",
+          zIndex: 0,
+        }}
+      />
+
+      {/* Dual Sidebar */}
+      <MuiSignupDualSidebar />
+
+      {/* Header Actions - Search and Login */}
+      <MuiHeaderActions />
+
+      {/* TaleTree Logo and Title */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: 48,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 40,
+          textAlign: "center",
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+          {/* Logo */}
+          <Box sx={{ width: 64, height: 64, mb: 2 }}>
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
+              alt="TaleTree Logo"
+              style={{ width: "100%", height: "100%", objectFit: "contain" }}
+            />
+          </Box>
+          {/* Subtitle */}
+          <Box
+            component="p"
+            sx={{
+              color: "rgba(255, 255, 255, 0.9)",
+              fontSize: { xs: "16px", md: "18px" },
+              maxWidth: "24rem",
+              margin: 0,
+            }}
+          >
+            A New Kind of Curriculum
+          </Box>
+        </Box>
+      </Box>
+
+      {/* SignupChatContainer with companion centered */}
+      <Box
+        sx={{
+          position: "relative",
+          zIndex: 10,
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <MuiSignupChatContainer
+          messages={chatMessages}
+          isAIThinking={false}
+        />
+      </Box>
+
+      {/* SignupChatInput for chatting */}
+      <Box
+        sx={{
+          position: "absolute",
+          bottom: 32,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 30,
+          width: "100%",
+          maxWidth: "32rem",
+          px: 2,
+        }}
+      >
+        <MuiSignupChatInput
+          onSendMessage={handleSendMessage}
+          placeholder="Ask me anything..."
+        />
+      </Box>
+
+      {/* Scroll Indicator */}
+      <Box
+        sx={{
+          position: "absolute",
+          bottom: 16,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 20,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          color: "rgba(255, 255, 255, 0.8)",
+          animation: "bounce 1s infinite",
+          "@keyframes bounce": {
+            "0%, 100%": {
+              transform: "translateX(-50%) translateY(0)",
+            },
+            "50%": {
+              transform: "translateX(-50%) translateY(-10px)",
+            },
+          },
+        }}
+      >
+        <Box
+          sx={{
+            width: 24,
+            height: 40,
+            border: "2px solid rgba(255, 255, 255, 0.6)",
+            borderRadius: "20px",
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <Box
+            sx={{
+              width: 4,
+              height: 12,
+              bgcolor: "rgba(255, 255, 255, 0.6)",
+              borderRadius: "2px",
+              mt: 1,
+              animation: "pulse 2s infinite",
+            }}
+          />
+        </Box>
+        <Box
+          component="svg"
+          sx={{ width: 16, height: 16, mt: 0.5 }}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 14l-7 7m0 0l-7-7m7 7V3"
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default MuiHeroSection;

--- a/client/components/signup-mui/MuiHeroSection.jsx
+++ b/client/components/signup-mui/MuiHeroSection.jsx
@@ -82,7 +82,13 @@ const MuiHeroSection = () => {
           textAlign: "center",
         }}
       >
-        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+        >
           {/* Logo */}
           <Box sx={{ width: 64, height: 64, mb: 2 }}>
             <img
@@ -118,10 +124,7 @@ const MuiHeroSection = () => {
           justifyContent: "center",
         }}
       >
-        <MuiSignupChatContainer
-          messages={chatMessages}
-          isAIThinking={false}
-        />
+        <MuiSignupChatContainer messages={chatMessages} isAIThinking={false} />
       </Box>
 
       {/* SignupChatInput for chatting */}

--- a/client/components/signup-mui/MuiHeroSection.jsx
+++ b/client/components/signup-mui/MuiHeroSection.jsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { Box } from "@mui/material";
-import { MuiSignupChatContainer } from "./MuiSignupChatContainer";
-import { MuiSignupChatInput } from "./MuiSignupChatInput";
-import { MuiHeaderActions } from "./MuiHeaderActions";
-import { MuiSignupDualSidebar } from "./MuiSignupDualSidebar";
+import { MuiSignupChatContainer } from "./MuiSignupChatContainer.jsx";
+import { MuiSignupChatInput } from "./MuiSignupChatInput.jsx";
+import { MuiHeaderActions } from "./MuiHeaderActions.jsx";
+import { MuiSignupDualSidebar } from "./MuiSignupDualSidebar.jsx";
 
 const MuiHeroSection = () => {
   const [chatMessages, setChatMessages] = useState([

--- a/client/components/signup-mui/MuiHeroSection.tsx
+++ b/client/components/signup-mui/MuiHeroSection.tsx
@@ -1,0 +1,217 @@
+import { useState } from "react";
+import { Box } from "@mui/material";
+import { MuiSignupChatContainer } from "./MuiSignupChatContainer";
+import { MuiSignupChatInput } from "./MuiSignupChatInput";
+import { MuiHeaderActions } from "./MuiHeaderActions";
+import { MuiSignupDualSidebar } from "./MuiSignupDualSidebar";
+
+interface ChatMessage {
+  id: string;
+  type: "text" | "system";
+  sender: "AI" | "Kid";
+  content?: string;
+  timestamp: Date;
+}
+
+const MuiHeroSection = () => {
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
+    {
+      id: "1",
+      type: "text" as const,
+      sender: "AI" as const,
+      content:
+        "It's time to start. Share the beautiful, magical stories and stories.",
+      timestamp: new Date(),
+    },
+  ]);
+
+  const handleSendMessage = (message: string) => {
+    // Add user message
+    const userMessage = {
+      id: Date.now().toString(),
+      type: "text" as const,
+      sender: "Kid" as const,
+      content: message,
+      timestamp: new Date(),
+    };
+    setChatMessages((prev) => [...prev, userMessage]);
+
+    // Simulate AI response after a delay
+    setTimeout(() => {
+      const aiResponse = {
+        id: (Date.now() + 1).toString(),
+        type: "text" as const,
+        sender: "AI" as const,
+        content: `Thanks for sharing: "${message}". Let's explore this together!`,
+        timestamp: new Date(),
+      };
+      setChatMessages((prev) => [...prev, aiResponse]);
+    }, 1500);
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        height: "100vh",
+        width: "100%",
+        overflow: "hidden",
+      }}
+    >
+      {/* Background Image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          backgroundImage: `url('https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fdb72aca99fd341bf810b2c50e7d6006a?format=webp&width=800')`,
+          backgroundPosition: "center center",
+          backgroundSize: "cover",
+          backgroundRepeat: "no-repeat",
+          zIndex: 0,
+        }}
+      />
+
+      {/* Dual Sidebar */}
+      <MuiSignupDualSidebar />
+
+      {/* Header Actions - Search and Login */}
+      <MuiHeaderActions />
+
+      {/* TaleTree Logo and Title */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: 48,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 40,
+          textAlign: "center",
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+          {/* Logo */}
+          <Box sx={{ width: 64, height: 64, mb: 2 }}>
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F956eb6364f77469eb6b19c2791e6b43a?format=webp&width=800"
+              alt="TaleTree Logo"
+              style={{ width: "100%", height: "100%", objectFit: "contain" }}
+            />
+          </Box>
+          {/* Subtitle */}
+          <Box
+            component="p"
+            sx={{
+              color: "rgba(255, 255, 255, 0.9)",
+              fontSize: { xs: "16px", md: "18px" },
+              maxWidth: "24rem",
+              margin: 0,
+            }}
+          >
+            A New Kind of Curriculum
+          </Box>
+        </Box>
+      </Box>
+
+      {/* SignupChatContainer with companion centered */}
+      <Box
+        sx={{
+          position: "relative",
+          zIndex: 10,
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <MuiSignupChatContainer
+          messages={chatMessages}
+          isAIThinking={false}
+        />
+      </Box>
+
+      {/* SignupChatInput for chatting */}
+      <Box
+        sx={{
+          position: "absolute",
+          bottom: 32,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 30,
+          width: "100%",
+          maxWidth: "32rem",
+          px: 2,
+        }}
+      >
+        <MuiSignupChatInput
+          onSendMessage={handleSendMessage}
+          placeholder="Ask me anything..."
+        />
+      </Box>
+
+      {/* Scroll Indicator */}
+      <Box
+        sx={{
+          position: "absolute",
+          bottom: 16,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 20,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          color: "rgba(255, 255, 255, 0.8)",
+          animation: "bounce 1s infinite",
+          "@keyframes bounce": {
+            "0%, 100%": {
+              transform: "translateX(-50%) translateY(0)",
+            },
+            "50%": {
+              transform: "translateX(-50%) translateY(-10px)",
+            },
+          },
+        }}
+      >
+        <Box
+          sx={{
+            width: 24,
+            height: 40,
+            border: "2px solid rgba(255, 255, 255, 0.6)",
+            borderRadius: "20px",
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <Box
+            sx={{
+              width: 4,
+              height: 12,
+              bgcolor: "rgba(255, 255, 255, 0.6)",
+              borderRadius: "2px",
+              mt: 1,
+              animation: "pulse 2s infinite",
+            }}
+          />
+        </Box>
+        <Box
+          component="svg"
+          sx={{ width: 16, height: 16, mt: 0.5 }}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 14l-7 7m0 0l-7-7m7 7V3"
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default MuiHeroSection;

--- a/client/components/signup-mui/MuiIntroducingSection.jsx
+++ b/client/components/signup-mui/MuiIntroducingSection.jsx
@@ -1,0 +1,353 @@
+import { Box, Container, Typography, Grid } from "@mui/material";
+
+const MuiIntroducingSection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 8 }}>
+      {/* Main layout - larger proportions like second image */}
+      <Grid container spacing={4} sx={{ mb: 6 }}>
+        {/* Left - Large fox illustration card */}
+        <Grid item xs={12} md={8}>
+          <Box
+            sx={{
+              bgcolor: "white",
+              borderRadius: "24px",
+              boxShadow: "0 20px 40px rgba(0, 0, 0, 0.1)",
+              overflow: "hidden",
+              height: "400px",
+            }}
+          >
+            {/* Fox character scene with starry night */}
+            <Box
+              sx={{
+                background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 30%, #4c1d95 100%)",
+                height: "100%",
+                position: "relative",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                overflow: "hidden",
+              }}
+            >
+              {/* Stars in background */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 20,
+                  right: 60,
+                  width: 8,
+                  height: 8,
+                  bgcolor: "#fbbf24",
+                  borderRadius: "50%",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 40,
+                  right: 120,
+                  width: 6,
+                  height: 6,
+                  bgcolor: "#60a5fa",
+                  borderRadius: "50%",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 60,
+                  left: 80,
+                  width: 5,
+                  height: 5,
+                  bgcolor: "#f472b6",
+                  borderRadius: "50%",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 80,
+                  right: 200,
+                  width: 7,
+                  height: 7,
+                  bgcolor: "#34d399",
+                  borderRadius: "50%",
+                }}
+              />
+
+              {/* Green hills/landscape */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  left: 0,
+                  width: "40%",
+                  height: 120,
+                  background: "linear-gradient(45deg, #22c55e, #16a34a)",
+                  borderRadius: "0 60% 0 0",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  right: 0,
+                  width: "35%",
+                  height: 100,
+                  background: "linear-gradient(-45deg, #22c55e, #16a34a)",
+                  borderRadius: "60% 0 0 0",
+                }}
+              />
+
+              {/* Yellow path/ground */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  left: "25%",
+                  right: "25%",
+                  height: 80,
+                  background: "linear-gradient(to top, #f59e0b, #fbbf24)",
+                  borderRadius: "20px 20px 0 0",
+                }}
+              />
+
+              {/* Large Fox character - centered and bigger */}
+              <Box
+                sx={{
+                  width: 140,
+                  height: 160,
+                  position: "relative",
+                  zIndex: 3,
+                  mt: -4,
+                }}
+              >
+                {/* Fox body */}
+                <Box
+                  sx={{
+                    width: 110,
+                    height: 110,
+                    bgcolor: "#f87171",
+                    borderRadius: "50% 50% 45% 45%",
+                    position: "relative",
+                    mx: "auto",
+                  }}
+                >
+                  {/* Fox ears */}
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: -20,
+                      left: 20,
+                      width: 22,
+                      height: 35,
+                      bgcolor: "#f87171",
+                      borderRadius: "50% 50% 20% 20%",
+                      transform: "rotate(-15deg)",
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: -20,
+                      right: 20,
+                      width: 22,
+                      height: 35,
+                      bgcolor: "#f87171",
+                      borderRadius: "50% 50% 20% 20%",
+                      transform: "rotate(15deg)",
+                    }}
+                  />
+
+                  {/* Fox face - white area */}
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 25,
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      width: 70,
+                      height: 55,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  >
+                    {/* Closed happy eyes */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 15,
+                        left: 16,
+                        width: 12,
+                        height: 8,
+                        bgcolor: "#000",
+                        borderRadius: "50% 50% 0 0",
+                        transform: "rotate(15deg)",
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 15,
+                        right: 16,
+                        width: 12,
+                        height: 8,
+                        bgcolor: "#000",
+                        borderRadius: "50% 50% 0 0",
+                        transform: "rotate(-15deg)",
+                      }}
+                    />
+                    
+                    {/* Nose */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 30,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        width: 8,
+                        height: 6,
+                        bgcolor: "#000",
+                        borderRadius: "50%",
+                      }}
+                    />
+
+                    {/* Happy smile */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 38,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        width: 20,
+                        height: 10,
+                        border: "2px solid #000",
+                        borderTop: "none",
+                        borderRadius: "0 0 20px 20px",
+                      }}
+                    />
+                  </Box>
+
+                  {/* Fox arms/hands */}
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 50,
+                      right: -25,
+                      width: 20,
+                      height: 35,
+                      bgcolor: "#f87171",
+                      borderRadius: "50% 50% 30% 30%",
+                      transform: "rotate(30deg)",
+                    }}
+                  />
+                </Box>
+
+                {/* Fox tail */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    bottom: 15,
+                    right: -30,
+                    width: 50,
+                    height: 40,
+                    bgcolor: "#f87171",
+                    borderRadius: "60% 40% 50% 50%",
+                    transform: "rotate(45deg)",
+                  }}
+                />
+              </Box>
+
+              {/* Small green object fox is holding */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  right: "35%",
+                  top: "45%",
+                  width: 18,
+                  height: 25,
+                  bgcolor: "#22c55e",
+                  borderRadius: "8px",
+                  zIndex: 4,
+                }}
+              />
+            </Box>
+          </Box>
+        </Grid>
+
+        {/* Right - Family photo card */}
+        <Grid item xs={12} md={4}>
+          <Box
+            sx={{
+              bgcolor: "white",
+              borderRadius: "24px",
+              boxShadow: "0 20px 40px rgba(0, 0, 0, 0.1)",
+              overflow: "hidden",
+              height: "400px",
+            }}
+          >
+            {/* Real family photo */}
+            <Box
+              sx={{
+                height: "300px",
+                backgroundImage: "url('https://cdn.builder.io/api/v1/image/assets%2F70505802e34346039d2fb8ec7db34579%2F01c22825301043d9946881a73b08b4f9?format=webp&width=800')",
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                position: "relative",
+              }}
+            />
+
+            {/* Card content */}
+            <Box sx={{ p: 3 }}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontSize: "18px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 1,
+                }}
+              >
+                TaleTree And kids
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "14px",
+                  color: "#6b7280",
+                }}
+              >
+                Jun 30,2025
+              </Typography>
+            </Box>
+          </Box>
+        </Grid>
+      </Grid>
+
+      {/* Bottom heading */}
+      <Box>
+        <Typography
+          variant="h2"
+          sx={{
+            fontSize: "32px",
+            fontWeight: 700,
+            color: "#1e1b4b",
+            mb: 1,
+          }}
+        >
+          Introducing TaleTree
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={{
+            fontSize: "16px",
+            color: "#6b7280",
+          }}
+        >
+          Jun 30,2025
+        </Typography>
+      </Box>
+    </Container>
+  );
+};
+
+export default MuiIntroducingSection;

--- a/client/components/signup-mui/MuiIntroducingSection.jsx
+++ b/client/components/signup-mui/MuiIntroducingSection.jsx
@@ -19,7 +19,8 @@ const MuiIntroducingSection = () => {
             {/* Fox character scene with starry night */}
             <Box
               sx={{
-                background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 30%, #4c1d95 100%)",
+                background:
+                  "linear-gradient(135deg, #1e1b4b 0%, #312e81 30%, #4c1d95 100%)",
                 height: "100%",
                 position: "relative",
                 display: "flex",
@@ -196,7 +197,7 @@ const MuiIntroducingSection = () => {
                         transform: "rotate(-15deg)",
                       }}
                     />
-                    
+
                     {/* Nose */}
                     <Box
                       sx={{
@@ -289,7 +290,8 @@ const MuiIntroducingSection = () => {
             <Box
               sx={{
                 height: "300px",
-                backgroundImage: "url('https://cdn.builder.io/api/v1/image/assets%2F70505802e34346039d2fb8ec7db34579%2F01c22825301043d9946881a73b08b4f9?format=webp&width=800')",
+                backgroundImage:
+                  "url('https://cdn.builder.io/api/v1/image/assets%2F70505802e34346039d2fb8ec7db34579%2F01c22825301043d9946881a73b08b4f9?format=webp&width=800')",
                 backgroundSize: "cover",
                 backgroundPosition: "center",
                 position: "relative",

--- a/client/components/signup-mui/MuiIntroducingSection.tsx
+++ b/client/components/signup-mui/MuiIntroducingSection.tsx
@@ -1,144 +1,380 @@
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Container, Typography, Grid } from "@mui/material";
 
 const MuiIntroducingSection = () => {
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Typography
-        variant="h4"
-        sx={{
-          fontSize: "24px",
-          fontWeight: 700,
-          color: "#111827",
-          mb: 4,
-        }}
-      >
-        Introducing TaleTree
-      </Typography>
-
-      {/* Single centered card with fox character */}
-      <Box sx={{ display: "flex", justifyContent: "center" }}>
-        <Box
-          sx={{
-            width: { xs: "100%", md: "70%" },
-            maxWidth: "600px",
-            bgcolor: "white",
-            borderRadius: "12px",
-            boxShadow: "0 10px 25px rgba(0, 0, 0, 0.1)",
-            overflow: "hidden",
-          }}
-        >
-          {/* Image section with fox character */}
+      {/* Two column layout as per reference image */}
+      <Grid container spacing={3}>
+        {/* Left - Large illustration card (60% width) */}
+        <Grid item xs={12} md={7}>
           <Box
             sx={{
-              background: "linear-gradient(135deg, #1e3a8a 0%, #3b82f6 100%)",
-              height: 300,
-              position: "relative",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 8px 25px rgba(0, 0, 0, 0.1)",
+              overflow: "hidden",
+              height: "300px",
             }}
           >
-            {/* Fox character placeholder */}
+            {/* Fox character scene */}
             <Box
               sx={{
-                width: 120,
-                height: 120,
-                bgcolor: "#ef4444",
-                borderRadius: "50% 50% 0 50%",
+                background: "linear-gradient(135deg, #312e81 0%, #3730a3 50%, #1e1b4b 100%)",
+                height: "100%",
                 position: "relative",
-                transform: "rotate(-15deg)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
               }}
             >
-              {/* Fox ears */}
+              {/* Background elements - plants */}
               <Box
                 sx={{
                   position: "absolute",
-                  top: -20,
                   left: 20,
-                  width: 20,
-                  height: 30,
-                  bgcolor: "#ef4444",
-                  borderRadius: "50% 50% 0 0",
-                  transform: "rotate(-30deg)",
+                  bottom: 60,
+                  width: 80,
+                  height: 60,
+                  bgcolor: "#22c55e",
+                  borderRadius: "50% 50% 40% 60%",
                 }}
               />
               <Box
                 sx={{
                   position: "absolute",
-                  top: -20,
-                  right: 20,
-                  width: 20,
-                  height: 30,
-                  bgcolor: "#ef4444",
-                  borderRadius: "50% 50% 0 0",
-                  transform: "rotate(30deg)",
+                  right: 30,
+                  bottom: 50,
+                  width: 60,
+                  height: 80,
+                  bgcolor: "#16a34a",
+                  borderRadius: "50% 40% 50% 30%",
                 }}
               />
-              {/* Fox eyes */}
+
+              {/* Fox character */}
+              <Box
+                sx={{
+                  width: 100,
+                  height: 120,
+                  position: "relative",
+                  zIndex: 2,
+                }}
+              >
+                {/* Fox body */}
+                <Box
+                  sx={{
+                    width: 80,
+                    height: 80,
+                    bgcolor: "#ef4444",
+                    borderRadius: "50% 50% 40% 40%",
+                    position: "relative",
+                    mx: "auto",
+                  }}
+                >
+                  {/* Fox ears */}
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: -15,
+                      left: 15,
+                      width: 16,
+                      height: 25,
+                      bgcolor: "#ef4444",
+                      borderRadius: "50% 50% 10% 10%",
+                      transform: "rotate(-20deg)",
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: -15,
+                      right: 15,
+                      width: 16,
+                      height: 25,
+                      bgcolor: "#ef4444",
+                      borderRadius: "50% 50% 10% 10%",
+                      transform: "rotate(20deg)",
+                    }}
+                  />
+
+                  {/* Fox face - white circle */}
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 20,
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      width: 50,
+                      height: 40,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  >
+                    {/* Eyes */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 8,
+                        left: 12,
+                        width: 8,
+                        height: 12,
+                        bgcolor: "#000",
+                        borderRadius: "50%",
+                      }}
+                    />
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 8,
+                        right: 12,
+                        width: 8,
+                        height: 12,
+                        bgcolor: "#000",
+                        borderRadius: "50%",
+                      }}
+                    />
+                    {/* Nose */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 22,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        width: 6,
+                        height: 4,
+                        bgcolor: "#000",
+                        borderRadius: "50%",
+                      }}
+                    />
+                  </Box>
+                </Box>
+
+                {/* Fox tail */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    bottom: 10,
+                    right: -20,
+                    width: 40,
+                    height: 30,
+                    bgcolor: "#ef4444",
+                    borderRadius: "70% 30% 50% 50%",
+                    transform: "rotate(45deg)",
+                  }}
+                />
+              </Box>
+
+              {/* Yellow ground path */}
               <Box
                 sx={{
                   position: "absolute",
-                  top: 30,
-                  left: 25,
-                  width: 15,
-                  height: 15,
-                  bgcolor: "white",
-                  borderRadius: "50%",
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  height: 60,
+                  background: "linear-gradient(to top, #fbbf24, #f59e0b)",
+                  borderRadius: "0 0 0 0",
+                }}
+              />
+
+              {/* Green ground on sides */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  left: 0,
+                  width: "30%",
+                  height: 80,
+                  background: "#22c55e",
+                  borderRadius: "0 50% 0 0",
                 }}
               />
               <Box
                 sx={{
                   position: "absolute",
-                  top: 30,
-                  right: 25,
-                  width: 15,
-                  height: 15,
-                  bgcolor: "white",
-                  borderRadius: "50%",
-                }}
-              />
-              {/* Fox nose */}
-              <Box
-                sx={{
-                  position: "absolute",
-                  top: 50,
-                  left: "50%",
-                  transform: "translateX(-50%)",
-                  width: 8,
-                  height: 6,
-                  bgcolor: "white",
-                  borderRadius: "50%",
+                  bottom: 0,
+                  right: 0,
+                  width: "30%",
+                  height: 80,
+                  background: "#22c55e",
+                  borderRadius: "50% 0 0 0",
                 }}
               />
             </Box>
+          </Box>
+        </Grid>
 
-            {/* Green ground area */}
+        {/* Right - Small photo card (40% width) */}
+        <Grid item xs={12} md={5}>
+          <Box
+            sx={{
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 8px 25px rgba(0, 0, 0, 0.1)",
+              overflow: "hidden",
+              height: "300px",
+            }}
+          >
+            {/* Family photo */}
             <Box
               sx={{
-                position: "absolute",
-                bottom: 0,
-                left: 0,
-                right: 0,
-                height: 80,
-                background: "linear-gradient(to top, #22c55e, #16a34a)",
-                borderRadius: "0 0 50% 50% / 0 0 100px 100px",
-              }}
-            />
-          </Box>
-
-          {/* Caption */}
-          <Box sx={{ p: 3, textAlign: "center" }}>
-            <Typography
-              variant="body2"
-              sx={{
-                color: "#6b7280",
-                fontSize: "14px",
+                height: "220px",
+                background: "linear-gradient(135deg, #fef3c7, #fbbf24)",
+                position: "relative",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
               }}
             >
-              Families that talk
-            </Typography>
+              {/* Simulated family photo with multiple people */}
+              <Box sx={{ display: "flex", gap: 1, alignItems: "end" }}>
+                {/* Child 1 */}
+                <Box
+                  sx={{
+                    width: 40,
+                    height: 50,
+                    bgcolor: "#f97316",
+                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
+                    position: "relative",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 8,
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      width: 20,
+                      height: 20,
+                      bgcolor: "#fed7aa",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+
+                {/* Child 2 */}
+                <Box
+                  sx={{
+                    width: 35,
+                    height: 45,
+                    bgcolor: "#ec4899",
+                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
+                    position: "relative",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 6,
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      width: 18,
+                      height: 18,
+                      bgcolor: "#fce7f3",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+
+                {/* Child 3 */}
+                <Box
+                  sx={{
+                    width: 38,
+                    height: 48,
+                    bgcolor: "#06b6d4",
+                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
+                    position: "relative",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 7,
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      width: 19,
+                      height: 19,
+                      bgcolor: "#cffafe",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+
+                {/* Child 4 */}
+                <Box
+                  sx={{
+                    width: 36,
+                    height: 46,
+                    bgcolor: "#8b5cf6",
+                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
+                    position: "relative",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 6,
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      width: 18,
+                      height: 18,
+                      bgcolor: "#ede9fe",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+              </Box>
+            </Box>
+
+            {/* Card content */}
+            <Box sx={{ p: 2 }}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 0.5,
+                }}
+              >
+                TaleTree And kids
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#6b7280",
+                }}
+              >
+                Jun 30,2025
+              </Typography>
+            </Box>
           </Box>
-        </Box>
+        </Grid>
+      </Grid>
+
+      {/* Bottom heading as per reference */}
+      <Box sx={{ mt: 4 }}>
+        <Typography
+          variant="h4"
+          sx={{
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#111827",
+            mb: 0.5,
+          }}
+        >
+          Introducing TaleTree
+        </Typography>
+        <Typography
+          variant="caption"
+          sx={{
+            fontSize: "12px",
+            color: "#6b7280",
+          }}
+        >
+          Jun 30,2025
+        </Typography>
       </Box>
     </Container>
   );

--- a/client/components/signup-mui/MuiIntroducingSection.tsx
+++ b/client/components/signup-mui/MuiIntroducingSection.tsx
@@ -2,71 +2,132 @@ import { Box, Container, Typography, Grid } from "@mui/material";
 
 const MuiIntroducingSection = () => {
   return (
-    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      {/* Two column layout as per reference image */}
-      <Grid container spacing={3}>
-        {/* Left - Large illustration card (60% width) */}
-        <Grid item xs={12} md={7}>
+    <Container maxWidth="xl" sx={{ px: 4, py: 8 }}>
+      {/* Main layout - larger proportions like second image */}
+      <Grid container spacing={4} sx={{ mb: 6 }}>
+        {/* Left - Large fox illustration card */}
+        <Grid item xs={12} md={8}>
           <Box
             sx={{
               bgcolor: "white",
-              borderRadius: "16px",
-              boxShadow: "0 8px 25px rgba(0, 0, 0, 0.1)",
+              borderRadius: "24px",
+              boxShadow: "0 20px 40px rgba(0, 0, 0, 0.1)",
               overflow: "hidden",
-              height: "300px",
+              height: "400px",
             }}
           >
-            {/* Fox character scene */}
+            {/* Fox character scene with starry night */}
             <Box
               sx={{
-                background: "linear-gradient(135deg, #312e81 0%, #3730a3 50%, #1e1b4b 100%)",
+                background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 30%, #4c1d95 100%)",
                 height: "100%",
                 position: "relative",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
+                overflow: "hidden",
               }}
             >
-              {/* Background elements - plants */}
+              {/* Stars in background */}
               <Box
                 sx={{
                   position: "absolute",
-                  left: 20,
-                  bottom: 60,
-                  width: 80,
-                  height: 60,
-                  bgcolor: "#22c55e",
-                  borderRadius: "50% 50% 40% 60%",
+                  top: 20,
+                  right: 60,
+                  width: 8,
+                  height: 8,
+                  bgcolor: "#fbbf24",
+                  borderRadius: "50%",
                 }}
               />
               <Box
                 sx={{
                   position: "absolute",
-                  right: 30,
-                  bottom: 50,
-                  width: 60,
-                  height: 80,
-                  bgcolor: "#16a34a",
-                  borderRadius: "50% 40% 50% 30%",
+                  top: 40,
+                  right: 120,
+                  width: 6,
+                  height: 6,
+                  bgcolor: "#60a5fa",
+                  borderRadius: "50%",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 60,
+                  left: 80,
+                  width: 5,
+                  height: 5,
+                  bgcolor: "#f472b6",
+                  borderRadius: "50%",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 80,
+                  right: 200,
+                  width: 7,
+                  height: 7,
+                  bgcolor: "#34d399",
+                  borderRadius: "50%",
                 }}
               />
 
-              {/* Fox character */}
+              {/* Green hills/landscape */}
               <Box
                 sx={{
-                  width: 100,
+                  position: "absolute",
+                  bottom: 0,
+                  left: 0,
+                  width: "40%",
                   height: 120,
+                  background: "linear-gradient(45deg, #22c55e, #16a34a)",
+                  borderRadius: "0 60% 0 0",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  right: 0,
+                  width: "35%",
+                  height: 100,
+                  background: "linear-gradient(-45deg, #22c55e, #16a34a)",
+                  borderRadius: "60% 0 0 0",
+                }}
+              />
+
+              {/* Yellow path/ground */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  left: "25%",
+                  right: "25%",
+                  height: 80,
+                  background: "linear-gradient(to top, #f59e0b, #fbbf24)",
+                  borderRadius: "20px 20px 0 0",
+                }}
+              />
+
+              {/* Large Fox character - centered and bigger */}
+              <Box
+                sx={{
+                  width: 140,
+                  height: 160,
                   position: "relative",
-                  zIndex: 2,
+                  zIndex: 3,
+                  mt: -4,
                 }}
               >
                 {/* Fox body */}
                 <Box
                   sx={{
-                    width: 80,
-                    height: 80,
-                    bgcolor: "#ef4444",
-                    borderRadius: "50% 50% 40% 40%",
+                    width: 110,
+                    height: 110,
+                    bgcolor: "#f87171",
+                    borderRadius: "50% 50% 45% 45%",
                     position: "relative",
                     mx: "auto",
                   }}
@@ -75,266 +136,175 @@ const MuiIntroducingSection = () => {
                   <Box
                     sx={{
                       position: "absolute",
-                      top: -15,
-                      left: 15,
-                      width: 16,
-                      height: 25,
-                      bgcolor: "#ef4444",
-                      borderRadius: "50% 50% 10% 10%",
-                      transform: "rotate(-20deg)",
+                      top: -20,
+                      left: 20,
+                      width: 22,
+                      height: 35,
+                      bgcolor: "#f87171",
+                      borderRadius: "50% 50% 20% 20%",
+                      transform: "rotate(-15deg)",
                     }}
                   />
                   <Box
                     sx={{
                       position: "absolute",
-                      top: -15,
-                      right: 15,
-                      width: 16,
-                      height: 25,
-                      bgcolor: "#ef4444",
-                      borderRadius: "50% 50% 10% 10%",
-                      transform: "rotate(20deg)",
+                      top: -20,
+                      right: 20,
+                      width: 22,
+                      height: 35,
+                      bgcolor: "#f87171",
+                      borderRadius: "50% 50% 20% 20%",
+                      transform: "rotate(15deg)",
                     }}
                   />
 
-                  {/* Fox face - white circle */}
+                  {/* Fox face - white area */}
                   <Box
                     sx={{
                       position: "absolute",
-                      top: 20,
+                      top: 25,
                       left: "50%",
                       transform: "translateX(-50%)",
-                      width: 50,
-                      height: 40,
+                      width: 70,
+                      height: 55,
                       bgcolor: "white",
                       borderRadius: "50%",
                     }}
                   >
-                    {/* Eyes */}
+                    {/* Closed happy eyes */}
                     <Box
                       sx={{
                         position: "absolute",
-                        top: 8,
-                        left: 12,
-                        width: 8,
-                        height: 12,
+                        top: 15,
+                        left: 16,
+                        width: 12,
+                        height: 8,
                         bgcolor: "#000",
-                        borderRadius: "50%",
+                        borderRadius: "50% 50% 0 0",
+                        transform: "rotate(15deg)",
                       }}
                     />
                     <Box
                       sx={{
                         position: "absolute",
-                        top: 8,
-                        right: 12,
-                        width: 8,
-                        height: 12,
+                        top: 15,
+                        right: 16,
+                        width: 12,
+                        height: 8,
                         bgcolor: "#000",
-                        borderRadius: "50%",
+                        borderRadius: "50% 50% 0 0",
+                        transform: "rotate(-15deg)",
                       }}
                     />
+                    
                     {/* Nose */}
                     <Box
                       sx={{
                         position: "absolute",
-                        top: 22,
+                        top: 30,
                         left: "50%",
                         transform: "translateX(-50%)",
-                        width: 6,
-                        height: 4,
+                        width: 8,
+                        height: 6,
                         bgcolor: "#000",
                         borderRadius: "50%",
                       }}
                     />
+
+                    {/* Happy smile */}
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        top: 38,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        width: 20,
+                        height: 10,
+                        border: "2px solid #000",
+                        borderTop: "none",
+                        borderRadius: "0 0 20px 20px",
+                      }}
+                    />
                   </Box>
+
+                  {/* Fox arms/hands */}
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 50,
+                      right: -25,
+                      width: 20,
+                      height: 35,
+                      bgcolor: "#f87171",
+                      borderRadius: "50% 50% 30% 30%",
+                      transform: "rotate(30deg)",
+                    }}
+                  />
                 </Box>
 
                 {/* Fox tail */}
                 <Box
                   sx={{
                     position: "absolute",
-                    bottom: 10,
-                    right: -20,
-                    width: 40,
-                    height: 30,
-                    bgcolor: "#ef4444",
-                    borderRadius: "70% 30% 50% 50%",
+                    bottom: 15,
+                    right: -30,
+                    width: 50,
+                    height: 40,
+                    bgcolor: "#f87171",
+                    borderRadius: "60% 40% 50% 50%",
                     transform: "rotate(45deg)",
                   }}
                 />
               </Box>
 
-              {/* Yellow ground path */}
+              {/* Small green object fox is holding */}
               <Box
                 sx={{
                   position: "absolute",
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                  height: 60,
-                  background: "linear-gradient(to top, #fbbf24, #f59e0b)",
-                  borderRadius: "0 0 0 0",
-                }}
-              />
-
-              {/* Green ground on sides */}
-              <Box
-                sx={{
-                  position: "absolute",
-                  bottom: 0,
-                  left: 0,
-                  width: "30%",
-                  height: 80,
-                  background: "#22c55e",
-                  borderRadius: "0 50% 0 0",
-                }}
-              />
-              <Box
-                sx={{
-                  position: "absolute",
-                  bottom: 0,
-                  right: 0,
-                  width: "30%",
-                  height: 80,
-                  background: "#22c55e",
-                  borderRadius: "50% 0 0 0",
+                  right: "35%",
+                  top: "45%",
+                  width: 18,
+                  height: 25,
+                  bgcolor: "#22c55e",
+                  borderRadius: "8px",
+                  zIndex: 4,
                 }}
               />
             </Box>
           </Box>
         </Grid>
 
-        {/* Right - Small photo card (40% width) */}
-        <Grid item xs={12} md={5}>
+        {/* Right - Family photo card */}
+        <Grid item xs={12} md={4}>
           <Box
             sx={{
               bgcolor: "white",
-              borderRadius: "16px",
-              boxShadow: "0 8px 25px rgba(0, 0, 0, 0.1)",
+              borderRadius: "24px",
+              boxShadow: "0 20px 40px rgba(0, 0, 0, 0.1)",
               overflow: "hidden",
-              height: "300px",
+              height: "400px",
             }}
           >
-            {/* Family photo */}
+            {/* Real family photo */}
             <Box
               sx={{
-                height: "220px",
-                background: "linear-gradient(135deg, #fef3c7, #fbbf24)",
+                height: "300px",
+                backgroundImage: "url('https://cdn.builder.io/api/v1/image/assets%2F70505802e34346039d2fb8ec7db34579%2F01c22825301043d9946881a73b08b4f9?format=webp&width=800')",
+                backgroundSize: "cover",
+                backgroundPosition: "center",
                 position: "relative",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
               }}
-            >
-              {/* Simulated family photo with multiple people */}
-              <Box sx={{ display: "flex", gap: 1, alignItems: "end" }}>
-                {/* Child 1 */}
-                <Box
-                  sx={{
-                    width: 40,
-                    height: 50,
-                    bgcolor: "#f97316",
-                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
-                    position: "relative",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      position: "absolute",
-                      top: 8,
-                      left: "50%",
-                      transform: "translateX(-50%)",
-                      width: 20,
-                      height: 20,
-                      bgcolor: "#fed7aa",
-                      borderRadius: "50%",
-                    }}
-                  />
-                </Box>
-
-                {/* Child 2 */}
-                <Box
-                  sx={{
-                    width: 35,
-                    height: 45,
-                    bgcolor: "#ec4899",
-                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
-                    position: "relative",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      position: "absolute",
-                      top: 6,
-                      left: "50%",
-                      transform: "translateX(-50%)",
-                      width: 18,
-                      height: 18,
-                      bgcolor: "#fce7f3",
-                      borderRadius: "50%",
-                    }}
-                  />
-                </Box>
-
-                {/* Child 3 */}
-                <Box
-                  sx={{
-                    width: 38,
-                    height: 48,
-                    bgcolor: "#06b6d4",
-                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
-                    position: "relative",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      position: "absolute",
-                      top: 7,
-                      left: "50%",
-                      transform: "translateX(-50%)",
-                      width: 19,
-                      height: 19,
-                      bgcolor: "#cffafe",
-                      borderRadius: "50%",
-                    }}
-                  />
-                </Box>
-
-                {/* Child 4 */}
-                <Box
-                  sx={{
-                    width: 36,
-                    height: 46,
-                    bgcolor: "#8b5cf6",
-                    borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%",
-                    position: "relative",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      position: "absolute",
-                      top: 6,
-                      left: "50%",
-                      transform: "translateX(-50%)",
-                      width: 18,
-                      height: 18,
-                      bgcolor: "#ede9fe",
-                      borderRadius: "50%",
-                    }}
-                  />
-                </Box>
-              </Box>
-            </Box>
+            />
 
             {/* Card content */}
-            <Box sx={{ p: 2 }}>
+            <Box sx={{ p: 3 }}>
               <Typography
                 variant="h6"
                 sx={{
-                  fontSize: "16px",
+                  fontSize: "18px",
                   fontWeight: 600,
                   color: "#111827",
-                  mb: 0.5,
+                  mb: 1,
                 }}
               >
                 TaleTree And kids
@@ -342,7 +312,7 @@ const MuiIntroducingSection = () => {
               <Typography
                 variant="caption"
                 sx={{
-                  fontSize: "12px",
+                  fontSize: "14px",
                   color: "#6b7280",
                 }}
               >
@@ -353,23 +323,23 @@ const MuiIntroducingSection = () => {
         </Grid>
       </Grid>
 
-      {/* Bottom heading as per reference */}
-      <Box sx={{ mt: 4 }}>
+      {/* Bottom heading */}
+      <Box>
         <Typography
-          variant="h4"
+          variant="h2"
           sx={{
-            fontSize: "24px",
+            fontSize: "32px",
             fontWeight: 700,
-            color: "#111827",
-            mb: 0.5,
+            color: "#1e1b4b",
+            mb: 1,
           }}
         >
           Introducing TaleTree
         </Typography>
         <Typography
-          variant="caption"
+          variant="body1"
           sx={{
-            fontSize: "12px",
+            fontSize: "16px",
             color: "#6b7280",
           }}
         >

--- a/client/components/signup-mui/MuiIntroducingSection.tsx
+++ b/client/components/signup-mui/MuiIntroducingSection.tsx
@@ -19,7 +19,8 @@ const MuiIntroducingSection = () => {
             {/* Fox character scene with starry night */}
             <Box
               sx={{
-                background: "linear-gradient(135deg, #1e1b4b 0%, #312e81 30%, #4c1d95 100%)",
+                background:
+                  "linear-gradient(135deg, #1e1b4b 0%, #312e81 30%, #4c1d95 100%)",
                 height: "100%",
                 position: "relative",
                 display: "flex",
@@ -196,7 +197,7 @@ const MuiIntroducingSection = () => {
                         transform: "rotate(-15deg)",
                       }}
                     />
-                    
+
                     {/* Nose */}
                     <Box
                       sx={{
@@ -289,7 +290,8 @@ const MuiIntroducingSection = () => {
             <Box
               sx={{
                 height: "300px",
-                backgroundImage: "url('https://cdn.builder.io/api/v1/image/assets%2F70505802e34346039d2fb8ec7db34579%2F01c22825301043d9946881a73b08b4f9?format=webp&width=800')",
+                backgroundImage:
+                  "url('https://cdn.builder.io/api/v1/image/assets%2F70505802e34346039d2fb8ec7db34579%2F01c22825301043d9946881a73b08b4f9?format=webp&width=800')",
                 backgroundSize: "cover",
                 backgroundPosition: "center",
                 position: "relative",

--- a/client/components/signup-mui/MuiIntroducingSection.tsx
+++ b/client/components/signup-mui/MuiIntroducingSection.tsx
@@ -1,134 +1,145 @@
-import { Box, Container, Typography, Grid } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 
 const MuiIntroducingSection = () => {
   return (
-    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
-        <Typography
-          variant="h4"
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Typography
+        variant="h4"
+        sx={{
+          fontSize: "24px",
+          fontWeight: 700,
+          color: "#111827",
+          mb: 4,
+        }}
+      >
+        Introducing TaleTree
+      </Typography>
+
+      {/* Single centered card with fox character */}
+      <Box sx={{ display: "flex", justifyContent: "center" }}>
+        <Box
           sx={{
-            fontSize: "24px",
-            fontWeight: 700,
-            color: "#111827",
+            width: { xs: "100%", md: "70%" },
+            maxWidth: "600px",
+            bgcolor: "white",
+            borderRadius: "12px",
+            boxShadow: "0 10px 25px rgba(0, 0, 0, 0.1)",
+            overflow: "hidden",
           }}
         >
-          Introducing TaleTree
-        </Typography>
-      </Box>
-
-      <Grid container spacing={3}>
-        {/* Left - Character illustration */}
-        <Grid item xs={12} md={6}>
+          {/* Image section with fox character */}
           <Box
             sx={{
-              background: "linear-gradient(135deg, #fb923c 0%, #ef4444 100%)",
-              borderRadius: "12px",
-              p: 3,
-              height: 256,
+              background: "linear-gradient(135deg, #1e3a8a 0%, #3b82f6 100%)",
+              height: 300,
               position: "relative",
-              overflow: "hidden",
-            }}
-          >
-            <Box
-              sx={{
-                position: "absolute",
-                bottom: 16,
-                left: 16,
-              }}
-            >
-              <Box
-                sx={{
-                  width: 64,
-                  height: 80,
-                  bgcolor: "#ea580c",
-                  borderRadius: "50%",
-                  position: "relative",
-                }}
-              >
-                {/* Simple character representation */}
-                <Box
-                  sx={{
-                    position: "absolute",
-                    top: 8,
-                    left: 12,
-                    width: 8,
-                    height: 8,
-                    bgcolor: "white",
-                    borderRadius: "50%",
-                  }}
-                />
-                <Box
-                  sx={{
-                    position: "absolute",
-                    top: 8,
-                    right: 12,
-                    width: 8,
-                    height: 8,
-                    bgcolor: "white",
-                    borderRadius: "50%",
-                  }}
-                />
-                <Box
-                  sx={{
-                    position: "absolute",
-                    top: 24,
-                    left: "50%",
-                    transform: "translateX(-50%)",
-                    width: 4,
-                    height: 4,
-                    bgcolor: "white",
-                    borderRadius: "50%",
-                  }}
-                />
-              </Box>
-            </Box>
-            <Box
-              sx={{
-                position: "absolute",
-                inset: 0,
-                background: "linear-gradient(to top, rgba(34, 197, 94, 0.2) 0%, transparent 100%)",
-                borderRadius: "12px",
-              }}
-            />
-          </Box>
-        </Grid>
-
-        {/* Right - Family photo placeholder */}
-        <Grid item xs={12} md={6}>
-          <Box
-            sx={{
-              bgcolor: "#e5e7eb",
-              borderRadius: "12px",
-              height: 256,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
             }}
           >
-            <Box sx={{ textAlign: "center" }}>
+            {/* Fox character placeholder */}
+            <Box
+              sx={{
+                width: 120,
+                height: 120,
+                bgcolor: "#ef4444",
+                borderRadius: "50% 50% 0 50%",
+                position: "relative",
+                transform: "rotate(-15deg)",
+              }}
+            >
+              {/* Fox ears */}
               <Box
                 sx={{
-                  width: 80,
-                  height: 80,
-                  bgcolor: "#d1d5db",
-                  borderRadius: "50%",
-                  mx: "auto",
-                  mb: 2,
+                  position: "absolute",
+                  top: -20,
+                  left: 20,
+                  width: 20,
+                  height: 30,
+                  bgcolor: "#ef4444",
+                  borderRadius: "50% 50% 0 0",
+                  transform: "rotate(-30deg)",
                 }}
               />
-              <Typography
-                variant="body2"
+              <Box
                 sx={{
-                  color: "#6b7280",
-                  fontSize: "14px",
+                  position: "absolute",
+                  top: -20,
+                  right: 20,
+                  width: 20,
+                  height: 30,
+                  bgcolor: "#ef4444",
+                  borderRadius: "50% 50% 0 0",
+                  transform: "rotate(30deg)",
                 }}
-              >
-                Families that talk
-              </Typography>
+              />
+              {/* Fox eyes */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 30,
+                  left: 25,
+                  width: 15,
+                  height: 15,
+                  bgcolor: "white",
+                  borderRadius: "50%",
+                }}
+              />
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 30,
+                  right: 25,
+                  width: 15,
+                  height: 15,
+                  bgcolor: "white",
+                  borderRadius: "50%",
+                }}
+              />
+              {/* Fox nose */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 50,
+                  left: "50%",
+                  transform: "translateX(-50%)",
+                  width: 8,
+                  height: 6,
+                  bgcolor: "white",
+                  borderRadius: "50%",
+                }}
+              />
             </Box>
+
+            {/* Green ground area */}
+            <Box
+              sx={{
+                position: "absolute",
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: 80,
+                background: "linear-gradient(to top, #22c55e, #16a34a)",
+                borderRadius: "0 0 50% 50% / 0 0 100px 100px",
+              }}
+            />
           </Box>
-        </Grid>
-      </Grid>
+
+          {/* Caption */}
+          <Box sx={{ p: 3, textAlign: "center" }}>
+            <Typography
+              variant="body2"
+              sx={{
+                color: "#6b7280",
+                fontSize: "14px",
+              }}
+            >
+              Families that talk
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
     </Container>
   );
 };

--- a/client/components/signup-mui/MuiIntroducingSection.tsx
+++ b/client/components/signup-mui/MuiIntroducingSection.tsx
@@ -1,0 +1,136 @@
+import { Box, Container, Typography, Grid } from "@mui/material";
+
+const MuiIntroducingSection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+        <Typography
+          variant="h4"
+          sx={{
+            fontSize: "24px",
+            fontWeight: 700,
+            color: "#111827",
+          }}
+        >
+          Introducing TaleTree
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        {/* Left - Character illustration */}
+        <Grid item xs={12} md={6}>
+          <Box
+            sx={{
+              background: "linear-gradient(135deg, #fb923c 0%, #ef4444 100%)",
+              borderRadius: "12px",
+              p: 3,
+              height: 256,
+              position: "relative",
+              overflow: "hidden",
+            }}
+          >
+            <Box
+              sx={{
+                position: "absolute",
+                bottom: 16,
+                left: 16,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 64,
+                  height: 80,
+                  bgcolor: "#ea580c",
+                  borderRadius: "50%",
+                  position: "relative",
+                }}
+              >
+                {/* Simple character representation */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: 8,
+                    left: 12,
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: 8,
+                    right: 12,
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: 24,
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    width: 4,
+                    height: 4,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                  }}
+                />
+              </Box>
+            </Box>
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                background: "linear-gradient(to top, rgba(34, 197, 94, 0.2) 0%, transparent 100%)",
+                borderRadius: "12px",
+              }}
+            />
+          </Box>
+        </Grid>
+
+        {/* Right - Family photo placeholder */}
+        <Grid item xs={12} md={6}>
+          <Box
+            sx={{
+              bgcolor: "#e5e7eb",
+              borderRadius: "12px",
+              height: 256,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Box sx={{ textAlign: "center" }}>
+              <Box
+                sx={{
+                  width: 80,
+                  height: 80,
+                  bgcolor: "#d1d5db",
+                  borderRadius: "50%",
+                  mx: "auto",
+                  mb: 2,
+                }}
+              />
+              <Typography
+                variant="body2"
+                sx={{
+                  color: "#6b7280",
+                  fontSize: "14px",
+                }}
+              >
+                Families that talk
+              </Typography>
+            </Box>
+          </Box>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiIntroducingSection;

--- a/client/components/signup-mui/MuiLatestNewsSection.jsx
+++ b/client/components/signup-mui/MuiLatestNewsSection.jsx
@@ -1,0 +1,199 @@
+import { Box, Container, Typography, Grid, Card, Button } from "@mui/material";
+
+const MuiLatestNewsSection = () => {
+  const newsItems = [
+    {
+      title: "Set up camp in TaleTree Village",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=150&h=150&fit=crop&crop=face"
+    },
+    {
+      title: "Amplify Your Impact",
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=150&h=150&fit=crop&crop=center"
+    },
+    {
+      title: "Become an expert in Emerald City",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=150&h=150&fit=crop&crop=face"
+    },
+    {
+      title: "Join our movement",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?w=150&h=150&fit=crop&crop=face"
+    },
+    {
+      title: "Acquire a Treehouse in Emerald City",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=150&h=150&fit=crop&crop=center"
+    },
+    {
+      title: "Dream With Experts",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop&crop=face"
+    },
+  ];
+
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "18px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          Latest news
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      {/* 2-column layout with 3 cards each */}
+      <Grid container spacing={4}>
+        {/* Left Column */}
+        <Grid item xs={12} md={6}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {newsItems.slice(0, 3).map((item, i) => (
+              <Card
+                key={i}
+                sx={{
+                  bgcolor: "white",
+                  borderRadius: "12px",
+                  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.06)",
+                  overflow: "hidden",
+                  transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                  "&:hover": {
+                    transform: "translateY(-2px)",
+                    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
+                  },
+                }}
+              >
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  {/* Image thumbnail */}
+                  <Box
+                    sx={{
+                      width: 80,
+                      height: 80,
+                      flexShrink: 0,
+                      backgroundImage: `url(${item.image})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                      m: 2,
+                      borderRadius: "8px",
+                    }}
+                  />
+                  
+                  {/* Content */}
+                  <Box sx={{ flex: 1, p: 2, pl: 0 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontSize: "14px",
+                        fontWeight: 600,
+                        color: "#111827",
+                        mb: 0.5,
+                        lineHeight: 1.3,
+                      }}
+                    >
+                      {item.title}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontSize: "12px",
+                        color: "#6b7280",
+                      }}
+                    >
+                      {item.date}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Card>
+            ))}
+          </Box>
+        </Grid>
+
+        {/* Right Column */}
+        <Grid item xs={12} md={6}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {newsItems.slice(3, 6).map((item, i) => (
+              <Card
+                key={i + 3}
+                sx={{
+                  bgcolor: "white",
+                  borderRadius: "12px",
+                  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.06)",
+                  overflow: "hidden",
+                  transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                  "&:hover": {
+                    transform: "translateY(-2px)",
+                    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
+                  },
+                }}
+              >
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  {/* Image thumbnail */}
+                  <Box
+                    sx={{
+                      width: 80,
+                      height: 80,
+                      flexShrink: 0,
+                      backgroundImage: `url(${item.image})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                      m: 2,
+                      borderRadius: "8px",
+                    }}
+                  />
+                  
+                  {/* Content */}
+                  <Box sx={{ flex: 1, p: 2, pl: 0 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontSize: "14px",
+                        fontWeight: 600,
+                        color: "#111827",
+                        mb: 0.5,
+                        lineHeight: 1.3,
+                      }}
+                    >
+                      {item.title}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontSize: "12px",
+                        color: "#6b7280",
+                      }}
+                    >
+                      {item.date}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Card>
+            ))}
+          </Box>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiLatestNewsSection;

--- a/client/components/signup-mui/MuiLatestNewsSection.jsx
+++ b/client/components/signup-mui/MuiLatestNewsSection.jsx
@@ -5,38 +5,51 @@ const MuiLatestNewsSection = () => {
     {
       title: "Set up camp in TaleTree Village",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=150&h=150&fit=crop&crop=face",
     },
     {
       title: "Amplify Your Impact",
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=150&h=150&fit=crop&crop=center"
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=150&h=150&fit=crop&crop=center",
     },
     {
       title: "Become an expert in Emerald City",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=150&h=150&fit=crop&crop=face",
     },
     {
       title: "Join our movement",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?w=150&h=150&fit=crop&crop=face",
     },
     {
       title: "Acquire a Treehouse in Emerald City",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=150&h=150&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=150&h=150&fit=crop&crop=center",
     },
     {
       title: "Dream With Experts",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop&crop=face",
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{
@@ -98,7 +111,7 @@ const MuiLatestNewsSection = () => {
                       borderRadius: "8px",
                     }}
                   />
-                  
+
                   {/* Content */}
                   <Box sx={{ flex: 1, p: 2, pl: 0 }}>
                     <Typography
@@ -161,7 +174,7 @@ const MuiLatestNewsSection = () => {
                       borderRadius: "8px",
                     }}
                   />
-                  
+
                   {/* Content */}
                   <Box sx={{ flex: 1, p: 2, pl: 0 }}>
                     <Typography

--- a/client/components/signup-mui/MuiLatestNewsSection.tsx
+++ b/client/components/signup-mui/MuiLatestNewsSection.tsx
@@ -1,0 +1,83 @@
+import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+
+const MuiLatestNewsSection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "20px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          Latest news
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      <Grid container spacing={2}>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Grid item xs={6} md={3} key={i}>
+            <Card
+              sx={{
+                bgcolor: "#f3f4f6",
+                border: "none",
+                boxShadow: "none",
+                borderRadius: "8px",
+              }}
+            >
+              <CardContent sx={{ p: 1.5 }}>
+                <Box
+                  sx={{
+                    width: "100%",
+                    height: 80,
+                    bgcolor: "#e5e7eb",
+                    borderRadius: "6px",
+                    mb: 1,
+                  }}
+                />
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "12px",
+                    color: "#6b7280",
+                    mb: 0.5,
+                  }}
+                >
+                  News headline here
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: "12px",
+                    color: "#9ca3af",
+                  }}
+                >
+                  Jan 24, 2024
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiLatestNewsSection;

--- a/client/components/signup-mui/MuiLatestNewsSection.tsx
+++ b/client/components/signup-mui/MuiLatestNewsSection.tsx
@@ -1,12 +1,37 @@
-import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+import { Box, Container, Typography, Grid, Card, Button } from "@mui/material";
 
 const MuiLatestNewsSection = () => {
   const newsItems = [
-    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025" },
-    { title: "Consectetur adipiscing elit", date: "Jun 22, 2025" },
-    { title: "Sed do eiusmod tempor", date: "Jun 21, 2025" },
-    { title: "Incididunt ut labore", date: "Jun 20, 2025" },
-    { title: "Dolore magna aliqua", date: "Jun 19, 2025" },
+    {
+      title: "Set up camp in TaleTree Village",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=150&h=150&fit=crop&crop=face"
+    },
+    {
+      title: "Amplify Your Impact",
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=150&h=150&fit=crop&crop=center"
+    },
+    {
+      title: "Become an expert in Emerald City",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=150&h=150&fit=crop&crop=face"
+    },
+    {
+      title: "Join our movement",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?w=150&h=150&fit=crop&crop=face"
+    },
+    {
+      title: "Acquire a Treehouse in Emerald City",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=150&h=150&fit=crop&crop=center"
+    },
+    {
+      title: "Dream With Experts",
+      date: "Jun 30,2025",
+      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop&crop=face"
+    },
   ];
 
   return (
@@ -15,7 +40,7 @@ const MuiLatestNewsSection = () => {
         <Typography
           variant="h5"
           sx={{
-            fontSize: "20px",
+            fontSize: "18px",
             fontWeight: 600,
             color: "#111827",
           }}
@@ -39,61 +64,133 @@ const MuiLatestNewsSection = () => {
         </Button>
       </Box>
 
-      {/* 5 cards in horizontal layout */}
-      <Grid container spacing={3}>
-        {newsItems.map((item, i) => (
-          <Grid item xs={12} sm={6} md={4} lg={2.4} key={i}>
-            <Card
-              sx={{
-                bgcolor: "white",
-                borderRadius: "12px",
-                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
-                overflow: "hidden",
-                transition: "transform 0.2s ease, box-shadow 0.2s ease",
-                "&:hover": {
-                  transform: "translateY(-2px)",
-                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
-                },
-              }}
-            >
-              {/* Image thumbnail */}
-              <Box
+      {/* 2-column layout with 3 cards each */}
+      <Grid container spacing={4}>
+        {/* Left Column */}
+        <Grid item xs={12} md={6}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {newsItems.slice(0, 3).map((item, i) => (
+              <Card
+                key={i}
                 sx={{
-                  width: "100%",
-                  height: 120,
-                  bgcolor: "#f3f4f6",
-                  backgroundImage: "linear-gradient(45deg, #e5e7eb 25%, transparent 25%), linear-gradient(-45deg, #e5e7eb 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e5e7eb 75%), linear-gradient(-45deg, transparent 75%, #e5e7eb 75%)",
-                  backgroundSize: "20px 20px",
-                  backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+                  bgcolor: "white",
+                  borderRadius: "12px",
+                  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.06)",
+                  overflow: "hidden",
+                  transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                  "&:hover": {
+                    transform: "translateY(-2px)",
+                    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
+                  },
                 }}
-              />
+              >
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  {/* Image thumbnail */}
+                  <Box
+                    sx={{
+                      width: 80,
+                      height: 80,
+                      flexShrink: 0,
+                      backgroundImage: `url(${item.image})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                      m: 2,
+                      borderRadius: "8px",
+                    }}
+                  />
+                  
+                  {/* Content */}
+                  <Box sx={{ flex: 1, p: 2, pl: 0 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontSize: "14px",
+                        fontWeight: 600,
+                        color: "#111827",
+                        mb: 0.5,
+                        lineHeight: 1.3,
+                      }}
+                    >
+                      {item.title}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontSize: "12px",
+                        color: "#6b7280",
+                      }}
+                    >
+                      {item.date}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Card>
+            ))}
+          </Box>
+        </Grid>
 
-              <CardContent sx={{ p: 2 }}>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    fontSize: "14px",
-                    fontWeight: 500,
-                    color: "#111827",
-                    mb: 1,
-                    lineHeight: 1.4,
-                  }}
-                >
-                  {item.title}
-                </Typography>
-                <Typography
-                  variant="caption"
-                  sx={{
-                    fontSize: "12px",
-                    color: "#6b7280",
-                  }}
-                >
-                  {item.date}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
+        {/* Right Column */}
+        <Grid item xs={12} md={6}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {newsItems.slice(3, 6).map((item, i) => (
+              <Card
+                key={i + 3}
+                sx={{
+                  bgcolor: "white",
+                  borderRadius: "12px",
+                  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.06)",
+                  overflow: "hidden",
+                  transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                  "&:hover": {
+                    transform: "translateY(-2px)",
+                    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.1)",
+                  },
+                }}
+              >
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  {/* Image thumbnail */}
+                  <Box
+                    sx={{
+                      width: 80,
+                      height: 80,
+                      flexShrink: 0,
+                      backgroundImage: `url(${item.image})`,
+                      backgroundSize: "cover",
+                      backgroundPosition: "center",
+                      m: 2,
+                      borderRadius: "8px",
+                    }}
+                  />
+                  
+                  {/* Content */}
+                  <Box sx={{ flex: 1, p: 2, pl: 0 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontSize: "14px",
+                        fontWeight: 600,
+                        color: "#111827",
+                        mb: 0.5,
+                        lineHeight: 1.3,
+                      }}
+                    >
+                      {item.title}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontSize: "12px",
+                        color: "#6b7280",
+                      }}
+                    >
+                      {item.date}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Card>
+            ))}
+          </Box>
+        </Grid>
       </Grid>
     </Container>
   );

--- a/client/components/signup-mui/MuiLatestNewsSection.tsx
+++ b/client/components/signup-mui/MuiLatestNewsSection.tsx
@@ -1,9 +1,17 @@
 import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
 
 const MuiLatestNewsSection = () => {
+  const newsItems = [
+    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025" },
+    { title: "Consectetur adipiscing elit", date: "Jun 22, 2025" },
+    { title: "Sed do eiusmod tempor", date: "Jun 21, 2025" },
+    { title: "Incididunt ut labore", date: "Jun 20, 2025" },
+    { title: "Dolore magna aliqua", date: "Jun 19, 2025" },
+  ];
+
   return (
-    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
         <Typography
           variant="h5"
           sx={{
@@ -31,45 +39,56 @@ const MuiLatestNewsSection = () => {
         </Button>
       </Box>
 
-      <Grid container spacing={2}>
-        {Array.from({ length: 8 }).map((_, i) => (
-          <Grid item xs={6} md={3} key={i}>
+      {/* 5 cards in horizontal layout */}
+      <Grid container spacing={3}>
+        {newsItems.map((item, i) => (
+          <Grid item xs={12} sm={6} md={4} lg={2.4} key={i}>
             <Card
               sx={{
-                bgcolor: "#f3f4f6",
-                border: "none",
-                boxShadow: "none",
-                borderRadius: "8px",
+                bgcolor: "white",
+                borderRadius: "12px",
+                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+                overflow: "hidden",
+                transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
+                },
               }}
             >
-              <CardContent sx={{ p: 1.5 }}>
-                <Box
-                  sx={{
-                    width: "100%",
-                    height: 80,
-                    bgcolor: "#e5e7eb",
-                    borderRadius: "6px",
-                    mb: 1,
-                  }}
-                />
+              {/* Image thumbnail */}
+              <Box
+                sx={{
+                  width: "100%",
+                  height: 120,
+                  bgcolor: "#f3f4f6",
+                  backgroundImage: "linear-gradient(45deg, #e5e7eb 25%, transparent 25%), linear-gradient(-45deg, #e5e7eb 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #e5e7eb 75%), linear-gradient(-45deg, transparent 75%, #e5e7eb 75%)",
+                  backgroundSize: "20px 20px",
+                  backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+                }}
+              />
+
+              <CardContent sx={{ p: 2 }}>
                 <Typography
                   variant="body2"
                   sx={{
-                    fontSize: "12px",
-                    color: "#6b7280",
-                    mb: 0.5,
+                    fontSize: "14px",
+                    fontWeight: 500,
+                    color: "#111827",
+                    mb: 1,
+                    lineHeight: 1.4,
                   }}
                 >
-                  News headline here
+                  {item.title}
                 </Typography>
                 <Typography
                   variant="caption"
                   sx={{
                     fontSize: "12px",
-                    color: "#9ca3af",
+                    color: "#6b7280",
                   }}
                 >
-                  Jan 24, 2024
+                  {item.date}
                 </Typography>
               </CardContent>
             </Card>

--- a/client/components/signup-mui/MuiLatestNewsSection.tsx
+++ b/client/components/signup-mui/MuiLatestNewsSection.tsx
@@ -5,38 +5,51 @@ const MuiLatestNewsSection = () => {
     {
       title: "Set up camp in TaleTree Village",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=150&h=150&fit=crop&crop=face",
     },
     {
       title: "Amplify Your Impact",
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=150&h=150&fit=crop&crop=center"
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1503454537195-1dcabb73ffb9?w=150&h=150&fit=crop&crop=center",
     },
     {
       title: "Become an expert in Emerald City",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=150&h=150&fit=crop&crop=face",
     },
     {
       title: "Join our movement",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?w=150&h=150&fit=crop&crop=face",
     },
     {
       title: "Acquire a Treehouse in Emerald City",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=150&h=150&fit=crop&crop=center"
+      image:
+        "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=150&h=150&fit=crop&crop=center",
     },
     {
       title: "Dream With Experts",
       date: "Jun 30,2025",
-      image: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop&crop=face"
+      image:
+        "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=150&h=150&fit=crop&crop=face",
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{
@@ -98,7 +111,7 @@ const MuiLatestNewsSection = () => {
                       borderRadius: "8px",
                     }}
                   />
-                  
+
                   {/* Content */}
                   <Box sx={{ flex: 1, p: 2, pl: 0 }}>
                     <Typography
@@ -161,7 +174,7 @@ const MuiLatestNewsSection = () => {
                       borderRadius: "8px",
                     }}
                   />
-                  
+
                   {/* Content */}
                   <Box sx={{ flex: 1, p: 2, pl: 0 }}>
                     <Typography

--- a/client/components/signup-mui/MuiParentsSection.jsx
+++ b/client/components/signup-mui/MuiParentsSection.jsx
@@ -1,28 +1,46 @@
-import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+import {
+  Box,
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+} from "@mui/material";
 
 const MuiParentsSection = () => {
   const parentStories = [
-    { 
-      title: "Lorem ipsum dolor sit amet", 
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=400&h=240&fit=crop&crop=face"
+    {
+      title: "Lorem ipsum dolor sit amet",
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=400&h=240&fit=crop&crop=face",
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1581579438747-1dc8d17bbce4?w=400&h=240&fit=crop&crop=center",
-      hasAvatars: true
+    {
+      title: "Lorem ipsum dolor sit amet",
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1581579438747-1dc8d17bbce4?w=400&h=240&fit=crop&crop=center",
+      hasAvatars: true,
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1609220136736-443140cffec6?w=400&h=240&fit=crop&crop=center"
+    {
+      title: "Lorem ipsum dolor sit amet",
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1609220136736-443140cffec6?w=400&h=240&fit=crop&crop=center",
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{
@@ -162,7 +180,7 @@ const MuiParentsSection = () => {
                     }}
                   />
                 </Box>
-                
+
                 {/* Orange avatar */}
                 <Box
                   sx={{

--- a/client/components/signup-mui/MuiParentsSection.jsx
+++ b/client/components/signup-mui/MuiParentsSection.jsx
@@ -1,0 +1,319 @@
+import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+
+const MuiParentsSection = () => {
+  const parentStories = [
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=400&h=240&fit=crop&crop=face"
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1581579438747-1dc8d17bbce4?w=400&h=240&fit=crop&crop=center",
+      hasAvatars: true
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1609220136736-443140cffec6?w=400&h=240&fit=crop&crop=center"
+    },
+  ];
+
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "18px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          Parents
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      {/* 3 cards with different proportions */}
+      <Grid container spacing={3}>
+        {/* First card - larger */}
+        <Grid item xs={12} md={5}>
+          <Card
+            sx={{
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+              overflow: "hidden",
+              transition: "transform 0.2s ease, box-shadow 0.2s ease",
+              "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+              },
+            }}
+          >
+            {/* Family photo */}
+            <Box
+              sx={{
+                width: "100%",
+                height: 200,
+                backgroundImage: `url(${parentStories[0].image})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }}
+            />
+
+            <CardContent sx={{ p: 3 }}>
+              <Typography
+                variant="body1"
+                sx={{
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 1,
+                  lineHeight: 1.4,
+                }}
+              >
+                {parentStories[0].title}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#6b7280",
+                }}
+              >
+                {parentStories[0].date}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Second card - medium with avatars */}
+        <Grid item xs={12} md={3.5}>
+          <Card
+            sx={{
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+              overflow: "hidden",
+              transition: "transform 0.2s ease, box-shadow 0.2s ease",
+              "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+              },
+            }}
+          >
+            {/* Family photo with avatars overlay */}
+            <Box
+              sx={{
+                width: "100%",
+                height: 200,
+                backgroundImage: `url(${parentStories[1].image})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                position: "relative",
+              }}
+            >
+              {/* Cartoon avatars overlay */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 16,
+                  right: 16,
+                  display: "flex",
+                  gap: 1,
+                }}
+              >
+                {/* Purple avatar */}
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#a855f7",
+                    borderRadius: "50%",
+                    border: "2px solid white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+                
+                {/* Orange avatar */}
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#f97316",
+                    borderRadius: "50%",
+                    border: "2px solid white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+
+                {/* Blue avatar */}
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#3b82f6",
+                    borderRadius: "50%",
+                    border: "2px solid white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+
+                {/* Green avatar */}
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#22c55e",
+                    borderRadius: "50%",
+                    border: "2px solid white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+              </Box>
+            </Box>
+
+            <CardContent sx={{ p: 3 }}>
+              <Typography
+                variant="body1"
+                sx={{
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 1,
+                  lineHeight: 1.4,
+                }}
+              >
+                {parentStories[1].title}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#6b7280",
+                }}
+              >
+                {parentStories[1].date}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Third card - medium */}
+        <Grid item xs={12} md={3.5}>
+          <Card
+            sx={{
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+              overflow: "hidden",
+              transition: "transform 0.2s ease, box-shadow 0.2s ease",
+              "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+              },
+            }}
+          >
+            {/* Family photo */}
+            <Box
+              sx={{
+                width: "100%",
+                height: 200,
+                backgroundImage: `url(${parentStories[2].image})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }}
+            />
+
+            <CardContent sx={{ p: 3 }}>
+              <Typography
+                variant="body1"
+                sx={{
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 1,
+                  lineHeight: 1.4,
+                }}
+              >
+                {parentStories[2].title}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#6b7280",
+                }}
+              >
+                {parentStories[2].date}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiParentsSection;

--- a/client/components/signup-mui/MuiParentsSection.tsx
+++ b/client/components/signup-mui/MuiParentsSection.tsx
@@ -1,28 +1,46 @@
-import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+import {
+  Box,
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+} from "@mui/material";
 
 const MuiParentsSection = () => {
   const parentStories = [
-    { 
-      title: "Lorem ipsum dolor sit amet", 
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=400&h=240&fit=crop&crop=face"
+    {
+      title: "Lorem ipsum dolor sit amet",
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=400&h=240&fit=crop&crop=face",
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1581579438747-1dc8d17bbce4?w=400&h=240&fit=crop&crop=center",
-      hasAvatars: true
+    {
+      title: "Lorem ipsum dolor sit amet",
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1581579438747-1dc8d17bbce4?w=400&h=240&fit=crop&crop=center",
+      hasAvatars: true,
     },
-    { 
-      title: "Lorem ipsum dolor sit amet", 
-      date: "Jun 30,2025", 
-      image: "https://images.unsplash.com/photo-1609220136736-443140cffec6?w=400&h=240&fit=crop&crop=center"
+    {
+      title: "Lorem ipsum dolor sit amet",
+      date: "Jun 30,2025",
+      image:
+        "https://images.unsplash.com/photo-1609220136736-443140cffec6?w=400&h=240&fit=crop&crop=center",
     },
   ];
 
   return (
     <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 4,
+        }}
+      >
         <Typography
           variant="h5"
           sx={{
@@ -162,7 +180,7 @@ const MuiParentsSection = () => {
                     }}
                   />
                 </Box>
-                
+
                 {/* Orange avatar */}
                 <Box
                   sx={{

--- a/client/components/signup-mui/MuiParentsSection.tsx
+++ b/client/components/signup-mui/MuiParentsSection.tsx
@@ -2,9 +2,22 @@ import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mu
 
 const MuiParentsSection = () => {
   const parentStories = [
-    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025", image: "family1" },
-    { title: "Consectetur adipiscing elit", date: "Jun 22, 2025", image: "family2" },
-    { title: "Sed do eiusmod tempor", date: "Jun 21, 2025", image: "family3" },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1511593358241-7eea1f3c84e5?w=400&h=240&fit=crop&crop=face"
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1581579438747-1dc8d17bbce4?w=400&h=240&fit=crop&crop=center",
+      hasAvatars: true
+    },
+    { 
+      title: "Lorem ipsum dolor sit amet", 
+      date: "Jun 30,2025", 
+      image: "https://images.unsplash.com/photo-1609220136736-443140cffec6?w=400&h=240&fit=crop&crop=center"
+    },
   ];
 
   return (
@@ -13,7 +26,7 @@ const MuiParentsSection = () => {
         <Typography
           variant="h5"
           sx={{
-            fontSize: "20px",
+            fontSize: "18px",
             fontWeight: 600,
             color: "#111827",
           }}
@@ -37,88 +50,267 @@ const MuiParentsSection = () => {
         </Button>
       </Box>
 
-      {/* 3 cards with family photos */}
-      <Grid container spacing={4}>
-        {parentStories.map((story, i) => (
-          <Grid item xs={12} md={4} key={i}>
-            <Card
+      {/* 3 cards with different proportions */}
+      <Grid container spacing={3}>
+        {/* First card - larger */}
+        <Grid item xs={12} md={5}>
+          <Card
+            sx={{
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+              overflow: "hidden",
+              transition: "transform 0.2s ease, box-shadow 0.2s ease",
+              "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+              },
+            }}
+          >
+            {/* Family photo */}
+            <Box
               sx={{
-                bgcolor: "white",
-                borderRadius: "12px",
-                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
-                overflow: "hidden",
-                transition: "transform 0.2s ease, box-shadow 0.2s ease",
-                "&:hover": {
-                  transform: "translateY(-2px)",
-                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
-                },
+                width: "100%",
+                height: 200,
+                backgroundImage: `url(${parentStories[0].image})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
               }}
-            >
-              {/* Real family photo placeholder */}
-              <Box
+            />
+
+            <CardContent sx={{ p: 3 }}>
+              <Typography
+                variant="body1"
                 sx={{
-                  width: "100%",
-                  height: 180,
-                  bgcolor: "#fef3c7",
-                  position: "relative",
-                  overflow: "hidden",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 1,
+                  lineHeight: 1.4,
                 }}
               >
-                {/* Simulated family photo with warm colors */}
+                {parentStories[0].title}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#6b7280",
+                }}
+              >
+                {parentStories[0].date}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Second card - medium with avatars */}
+        <Grid item xs={12} md={3.5}>
+          <Card
+            sx={{
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+              overflow: "hidden",
+              transition: "transform 0.2s ease, box-shadow 0.2s ease",
+              "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+              },
+            }}
+          >
+            {/* Family photo with avatars overlay */}
+            <Box
+              sx={{
+                width: "100%",
+                height: 200,
+                backgroundImage: `url(${parentStories[1].image})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                position: "relative",
+              }}
+            >
+              {/* Cartoon avatars overlay */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  top: 16,
+                  right: 16,
+                  display: "flex",
+                  gap: 1,
+                }}
+              >
+                {/* Purple avatar */}
                 <Box
                   sx={{
-                    width: "80%",
-                    height: "70%",
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#a855f7",
                     borderRadius: "50%",
-                    background: i === 0
-                      ? "linear-gradient(135deg, #fed7aa, #fb923c)"
-                      : i === 1
-                      ? "linear-gradient(135deg, #ddd6fe, #a855f7)"
-                      : "linear-gradient(135deg, #bbf7d0, #22c55e)",
+                    border: "2px solid white",
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    position: "relative",
                   }}
                 >
-                  {/* Simple family representation */}
-                  <Box sx={{ display: "flex", gap: 0.5 }}>
-                    <Box sx={{ width: 12, height: 16, bgcolor: "white", borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%" }} />
-                    <Box sx={{ width: 10, height: 14, bgcolor: "white", borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%" }} />
-                    <Box sx={{ width: 8, height: 10, bgcolor: "white", borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%" }} />
-                  </Box>
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+                
+                {/* Orange avatar */}
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#f97316",
+                    borderRadius: "50%",
+                    border: "2px solid white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+
+                {/* Blue avatar */}
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#3b82f6",
+                    borderRadius: "50%",
+                    border: "2px solid white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
+                </Box>
+
+                {/* Green avatar */}
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#22c55e",
+                    borderRadius: "50%",
+                    border: "2px solid white",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 20,
+                      height: 20,
+                      bgcolor: "white",
+                      borderRadius: "50%",
+                    }}
+                  />
                 </Box>
               </Box>
+            </Box>
 
-              <CardContent sx={{ p: 3 }}>
-                <Typography
-                  variant="body1"
-                  sx={{
-                    fontSize: "16px",
-                    fontWeight: 600,
-                    color: "#111827",
-                    mb: 1,
-                    lineHeight: 1.4,
-                  }}
-                >
-                  {story.title}
-                </Typography>
-                <Typography
-                  variant="caption"
-                  sx={{
-                    fontSize: "12px",
-                    color: "#6b7280",
-                  }}
-                >
-                  {story.date}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
+            <CardContent sx={{ p: 3 }}>
+              <Typography
+                variant="body1"
+                sx={{
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 1,
+                  lineHeight: 1.4,
+                }}
+              >
+                {parentStories[1].title}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#6b7280",
+                }}
+              >
+                {parentStories[1].date}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Third card - medium */}
+        <Grid item xs={12} md={3.5}>
+          <Card
+            sx={{
+              bgcolor: "white",
+              borderRadius: "16px",
+              boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
+              overflow: "hidden",
+              transition: "transform 0.2s ease, box-shadow 0.2s ease",
+              "&:hover": {
+                transform: "translateY(-2px)",
+                boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+              },
+            }}
+          >
+            {/* Family photo */}
+            <Box
+              sx={{
+                width: "100%",
+                height: 200,
+                backgroundImage: `url(${parentStories[2].image})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }}
+            />
+
+            <CardContent sx={{ p: 3 }}>
+              <Typography
+                variant="body1"
+                sx={{
+                  fontSize: "16px",
+                  fontWeight: 600,
+                  color: "#111827",
+                  mb: 1,
+                  lineHeight: 1.4,
+                }}
+              >
+                {parentStories[2].title}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "12px",
+                  color: "#6b7280",
+                }}
+              >
+                {parentStories[2].date}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
       </Grid>
     </Container>
   );

--- a/client/components/signup-mui/MuiParentsSection.tsx
+++ b/client/components/signup-mui/MuiParentsSection.tsx
@@ -1,9 +1,15 @@
 import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
 
 const MuiParentsSection = () => {
+  const parentStories = [
+    { title: "Lorem ipsum dolor sit amet", date: "Jun 23, 2025", image: "family1" },
+    { title: "Consectetur adipiscing elit", date: "Jun 22, 2025", image: "family2" },
+    { title: "Sed do eiusmod tempor", date: "Jun 21, 2025", image: "family3" },
+  ];
+
   return (
-    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+    <Container maxWidth="xl" sx={{ px: 4, py: 6 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 4 }}>
         <Typography
           variant="h5"
           sx={{
@@ -31,45 +37,83 @@ const MuiParentsSection = () => {
         </Button>
       </Box>
 
-      <Grid container spacing={3}>
-        {Array.from({ length: 6 }).map((_, i) => (
+      {/* 3 cards with family photos */}
+      <Grid container spacing={4}>
+        {parentStories.map((story, i) => (
           <Grid item xs={12} md={4} key={i}>
             <Card
               sx={{
-                bgcolor: "#f3f4f6",
-                border: "none",
-                boxShadow: "none",
-                borderRadius: "8px",
+                bgcolor: "white",
+                borderRadius: "12px",
+                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+                overflow: "hidden",
+                transition: "transform 0.2s ease, box-shadow 0.2s ease",
+                "&:hover": {
+                  transform: "translateY(-2px)",
+                  boxShadow: "0 8px 15px rgba(0, 0, 0, 0.1)",
+                },
               }}
             >
-              <CardContent sx={{ p: 2 }}>
+              {/* Real family photo placeholder */}
+              <Box
+                sx={{
+                  width: "100%",
+                  height: 180,
+                  bgcolor: "#fef3c7",
+                  position: "relative",
+                  overflow: "hidden",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {/* Simulated family photo with warm colors */}
                 <Box
                   sx={{
-                    width: "100%",
-                    height: 128,
-                    bgcolor: "#e5e7eb",
-                    borderRadius: "6px",
-                    mb: 1.5,
-                  }}
-                />
-                <Typography
-                  variant="body2"
-                  sx={{
-                    fontSize: "14px",
-                    color: "#374151",
-                    mb: 1,
+                    width: "80%",
+                    height: "70%",
+                    borderRadius: "50%",
+                    background: i === 0
+                      ? "linear-gradient(135deg, #fed7aa, #fb923c)"
+                      : i === 1
+                      ? "linear-gradient(135deg, #ddd6fe, #a855f7)"
+                      : "linear-gradient(135deg, #bbf7d0, #22c55e)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    position: "relative",
                   }}
                 >
-                  Parent story title
+                  {/* Simple family representation */}
+                  <Box sx={{ display: "flex", gap: 0.5 }}>
+                    <Box sx={{ width: 12, height: 16, bgcolor: "white", borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%" }} />
+                    <Box sx={{ width: 10, height: 14, bgcolor: "white", borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%" }} />
+                    <Box sx={{ width: 8, height: 10, bgcolor: "white", borderRadius: "50% 50% 50% 50% / 60% 60% 40% 40%" }} />
+                  </Box>
+                </Box>
+              </Box>
+
+              <CardContent sx={{ p: 3 }}>
+                <Typography
+                  variant="body1"
+                  sx={{
+                    fontSize: "16px",
+                    fontWeight: 600,
+                    color: "#111827",
+                    mb: 1,
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {story.title}
                 </Typography>
                 <Typography
                   variant="caption"
                   sx={{
                     fontSize: "12px",
-                    color: "#9ca3af",
+                    color: "#6b7280",
                   }}
                 >
-                  Story description here
+                  {story.date}
                 </Typography>
               </CardContent>
             </Card>

--- a/client/components/signup-mui/MuiParentsSection.tsx
+++ b/client/components/signup-mui/MuiParentsSection.tsx
@@ -1,0 +1,83 @@
+import { Box, Container, Typography, Grid, Card, CardContent, Button } from "@mui/material";
+
+const MuiParentsSection = () => {
+  return (
+    <Container maxWidth="xl" sx={{ px: 4, py: 4 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+        <Typography
+          variant="h5"
+          sx={{
+            fontSize: "20px",
+            fontWeight: 600,
+            color: "#111827",
+          }}
+        >
+          Parents
+        </Typography>
+        <Button
+          sx={{
+            color: "#9333ea",
+            "&:hover": {
+              color: "#7c3aed",
+            },
+            fontSize: "14px",
+            fontWeight: 500,
+            textTransform: "none",
+            p: 0,
+            minWidth: "auto",
+          }}
+        >
+          View all
+        </Button>
+      </Box>
+
+      <Grid container spacing={3}>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Grid item xs={12} md={4} key={i}>
+            <Card
+              sx={{
+                bgcolor: "#f3f4f6",
+                border: "none",
+                boxShadow: "none",
+                borderRadius: "8px",
+              }}
+            >
+              <CardContent sx={{ p: 2 }}>
+                <Box
+                  sx={{
+                    width: "100%",
+                    height: 128,
+                    bgcolor: "#e5e7eb",
+                    borderRadius: "6px",
+                    mb: 1.5,
+                  }}
+                />
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "14px",
+                    color: "#374151",
+                    mb: 1,
+                  }}
+                >
+                  Parent story title
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: "12px",
+                    color: "#9ca3af",
+                  }}
+                >
+                  Story description here
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export default MuiParentsSection;

--- a/client/components/signup-mui/MuiPlansStrip.jsx
+++ b/client/components/signup-mui/MuiPlansStrip.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { Box, Container, Button, Chip, Typography } from "@mui/material";
+
+const MuiPlansStrip = ({ onShowPlans }) => {
+  return (
+    <Container maxWidth="xl" sx={{ py: 2, px: 3 }}>
+      <Box
+        sx={{
+          bgcolor: "#f9fafb",
+          border: "1px solid #e5e7eb",
+          borderRadius: "8px",
+          py: 1.5,
+          px: 3,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            flexWrap: "wrap",
+            gap: 2,
+          }}
+        >
+          {/* Left Side - New Badge + Text */}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+            <Chip
+              label="New"
+              sx={{
+                bgcolor: "#dcfce7",
+                color: "#166534",
+                fontSize: "12px",
+                fontWeight: 500,
+                height: "24px",
+              }}
+            />
+            <Typography
+              variant="body1"
+              sx={{
+                fontSize: "16px",
+                fontWeight: 500,
+                color: "#111827",
+              }}
+            >
+              TaleTree just got better!
+            </Typography>
+          </Box>
+
+          {/* Right Side - See Plans Button */}
+          <Button
+            onClick={onShowPlans}
+            sx={{
+              background: "linear-gradient(to right, #9333ea, #7c3aed)",
+              "&:hover": {
+                background: "linear-gradient(to right, #7c3aed, #6d28d9)",
+                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+              },
+              color: "white",
+              fontWeight: 500,
+              py: 1,
+              px: 3,
+              borderRadius: "25px",
+              transition: "all 0.2s ease",
+              textTransform: "none",
+              fontSize: "14px",
+              boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)",
+            }}
+          >
+            See plans
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default MuiPlansStrip;

--- a/client/components/signup-mui/MuiPlansStrip.tsx
+++ b/client/components/signup-mui/MuiPlansStrip.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { Box, Container, Button, Chip, Typography } from "@mui/material";
+
+interface MuiPlansStripProps {
+  onShowPlans?: () => void;
+}
+
+const MuiPlansStrip = ({ onShowPlans }: MuiPlansStripProps) => {
+  return (
+    <Container maxWidth="xl" sx={{ py: 2, px: 3 }}>
+      <Box
+        sx={{
+          bgcolor: "#f9fafb",
+          border: "1px solid #e5e7eb",
+          borderRadius: "8px",
+          py: 1.5,
+          px: 3,
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            flexWrap: "wrap",
+            gap: 2,
+          }}
+        >
+          {/* Left Side - New Badge + Text */}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+            <Chip
+              label="New"
+              sx={{
+                bgcolor: "#dcfce7",
+                color: "#166534",
+                fontSize: "12px",
+                fontWeight: 500,
+                height: "24px",
+              }}
+            />
+            <Typography
+              variant="body1"
+              sx={{
+                fontSize: "16px",
+                fontWeight: 500,
+                color: "#111827",
+              }}
+            >
+              TaleTree just got better!
+            </Typography>
+          </Box>
+
+          {/* Right Side - See Plans Button */}
+          <Button
+            onClick={onShowPlans}
+            sx={{
+              background: "linear-gradient(to right, #9333ea, #7c3aed)",
+              "&:hover": {
+                background: "linear-gradient(to right, #7c3aed, #6d28d9)",
+              },
+              color: "white",
+              fontWeight: 500,
+              py: 1,
+              px: 3,
+              borderRadius: "25px",
+              transition: "all 0.2s ease",
+              textTransform: "none",
+              fontSize: "14px",
+              boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)",
+              "&:hover": {
+                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+              },
+            }}
+          >
+            See plans
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default MuiPlansStrip;

--- a/client/components/signup-mui/MuiSignupChatContainer.jsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.jsx
@@ -1,0 +1,384 @@
+import { useState, useEffect } from "react";
+import { Box } from "@mui/material";
+import Lottie from "lottie-react";
+
+export function MuiSignupChatContainer({
+  messages,
+  isAIThinking = false,
+}) {
+  // State for Lottie animation data
+  const [animationData, setAnimationData] = useState(null);
+
+  // Load Lottie animation data
+  useEffect(() => {
+    const loadAnimation = async () => {
+      try {
+        const response = await fetch(
+          "https://cdn.builder.io/o/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2Faf1bb45b193d45099ddf3851679da168?alt=media&token=e1de5c73-b4dc-4ba8-add2-191d7b69446e&apiKey=da24af11bdbb4585b8e6eb6406b2daf9",
+        );
+        const data = await response.json();
+        setAnimationData(data);
+      } catch (error) {
+        console.error("Failed to load Lottie animation:", error);
+      }
+    };
+
+    loadAnimation();
+  }, []);
+
+  // Get the latest AI and Kid messages separately
+  const getLatestMessages = () => {
+    let latestAI = null;
+    let latestKid = null;
+
+    // Find the most recent AI and Kid messages
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.sender === "AI" && !latestAI) {
+        latestAI = message;
+      }
+      if (message.sender === "Kid" && !latestKid) {
+        latestKid = message;
+      }
+      if (latestAI && latestKid) break;
+    }
+
+    return { latestAI, latestKid };
+  };
+
+  const { latestAI, latestKid } = getLatestMessages();
+
+  const renderMessage = (message) => {
+    // AI text messages - positioned at companion mouth level
+    if (message.sender === "AI") {
+      return (
+        <Box
+          key={message.id}
+          sx={{
+            position: "absolute",
+            bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
+            left: { xs: "20%", sm: "25%", md: "30%", lg: "35%" },
+            transform: "translateX(-50%)",
+            zIndex: 10,
+            animation: "slideInLeft 0.6s ease-out",
+            "@keyframes slideInLeft": {
+              "0%": {
+                opacity: 0,
+                transform: "translateX(-70px) scale(0.95)",
+              },
+              "100%": {
+                opacity: 1,
+                transform: "translateX(-50%) scale(1)",
+              },
+            },
+          }}
+        >
+          <Box sx={{ maxWidth: { xs: "300px", sm: "384px", md: "448px" } }}>
+            <Box
+              sx={{
+                bgcolor: "#3b82f6",
+                color: "white",
+                p: { xs: 1, sm: 1.5 },
+                borderRadius: "16px",
+                borderBottomLeftRadius: "4px",
+                boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+                position: "relative",
+              }}
+            >
+              <Box
+                component="p"
+                sx={{
+                  fontSize: { xs: "12px", sm: "14px" },
+                  lineHeight: 1.6,
+                  margin: 0,
+                }}
+              >
+                {message.content}
+              </Box>
+              {/* Speech bubble tail pointing to companion */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  left: { xs: "8px", sm: "12px" },
+                  width: 0,
+                  height: 0,
+                  borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                  borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                  borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                  transform: "translateY(100%)",
+                }}
+              />
+            </Box>
+          </Box>
+        </Box>
+      );
+    }
+
+    // Kid messages - positioned below AI message on the right
+    return (
+      <Box
+        key={message.id}
+        sx={{
+          position: "absolute",
+          bottom: "112px",
+          right: "32px",
+          animation: "slideInRight 0.6s ease-out",
+          "@keyframes slideInRight": {
+            "0%": {
+              opacity: 0,
+              transform: "translateX(20px) scale(0.95)",
+            },
+            "100%": {
+              opacity: 1,
+              transform: "translateX(0) scale(1)",
+            },
+          },
+        }}
+      >
+        <Box sx={{ maxWidth: "300px" }}>
+          <Box
+            sx={{
+              bgcolor: "#22c55e",
+              color: "white",
+              p: 1.5,
+              borderRadius: "16px",
+              borderBottomRightRadius: "4px",
+              boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+              position: "relative",
+            }}
+          >
+            <Box
+              component="p"
+              sx={{
+                fontSize: "14px",
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {message.content}
+            </Box>
+            {/* Speech bubble tail */}
+            <Box
+              sx={{
+                position: "absolute",
+                bottom: 0,
+                right: "16px",
+                width: 0,
+                height: 0,
+                borderLeft: "8px solid transparent",
+                borderRight: "8px solid transparent",
+                borderTop: "8px solid #22c55e",
+                transform: "translateY(100%)",
+              }}
+            />
+          </Box>
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%", position: "relative" }}>
+      {/* Fixed Companion Character on left side above chat input and on ground - responsive */}
+      <Box
+        sx={{
+          position: "absolute",
+          bottom: { xs: 64, sm: 80, md: 96 },
+          left: { xs: "5%", sm: "8%", md: "12%", lg: "15%" },
+          transform: "translateX(0)",
+          zIndex: 10,
+          transition: "transform 0.3s ease",
+          "&:hover": {
+            transform: "scale(1.05)",
+          },
+        }}
+      >
+        <Box
+          sx={{
+            width: { xs: 192, sm: 256, md: 320, lg: 384 },
+            height: { xs: 192, sm: 256, md: 320, lg: 384 },
+            position: "relative",
+          }}
+        >
+          {/* Magical glow effect */}
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              borderRadius: "50%",
+              background: "radial-gradient(circle, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))",
+              filter: "blur(40px)",
+              animation: "pulse 2s infinite",
+            }}
+          />
+          {animationData ? (
+            <Lottie
+              animationData={animationData}
+              loop={true}
+              autoplay={true}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "contain",
+                filter: "drop-shadow(0 0 20px rgba(255, 255, 255, 0.3))",
+                position: "relative",
+                zIndex: 10,
+              }}
+            />
+          ) : (
+            // Fallback image while loading
+            <Box
+              component="img"
+              src="https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F39f348f7483547d18b45c8bfcdc8ad42?format=webp&width=800"
+              alt="AI Companion"
+              sx={{
+                width: "100%",
+                height: "100%",
+                objectFit: "contain",
+                filter: "drop-shadow(0 0 20px rgba(255, 255, 255, 0.3))",
+                position: "relative",
+                zIndex: 10,
+                animation: "gentleFloat 4s ease-in-out infinite",
+                "@keyframes gentleFloat": {
+                  "0%, 100%": {
+                    transform: "translateY(0px) rotate(0deg)",
+                  },
+                  "25%": {
+                    transform: "translateY(-10px) rotate(1deg)",
+                  },
+                  "50%": {
+                    transform: "translateY(-15px) rotate(0deg)",
+                  },
+                  "75%": {
+                    transform: "translateY(-5px) rotate(-1deg)",
+                  },
+                },
+              }}
+            />
+          )}
+        </Box>
+        {isAIThinking && (
+          <Box
+            sx={{
+              position: "absolute",
+              top: -48,
+              left: "50%",
+              transform: "translateX(-50%)",
+              animation: "bounce 1s infinite",
+            }}
+          >
+            <Box
+              sx={{
+                bgcolor: "#3b82f6",
+                color: "white",
+                px: 2,
+                py: 1,
+                borderRadius: "20px",
+                fontSize: "14px",
+                boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                    animation: "pulse 1.5s infinite",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                    animation: "pulse 1.5s infinite 0.2s",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                    animation: "pulse 1.5s infinite 0.4s",
+                  }}
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {/* Messages Container - positioned absolutely for precise placement */}
+      <Box sx={{ position: "relative", width: "100%", height: "100%" }}>
+        {/* Latest AI Message - above companion */}
+        {latestAI && renderMessage(latestAI)}
+
+        {/* Latest Kid Message - on the right */}
+        {latestKid && renderMessage(latestKid)}
+
+        {/* Default state when no messages */}
+        {!latestAI && !latestKid && (
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
+              left: { xs: "20%", sm: "25%", md: "30%", lg: "35%" },
+              transform: "translateX(-50%)",
+              zIndex: 10,
+            }}
+          >
+            <Box sx={{ maxWidth: { xs: "300px", sm: "384px", md: "448px" } }}>
+              <Box
+                sx={{
+                  bgcolor: "#3b82f6",
+                  color: "white",
+                  p: { xs: 1, sm: 1.5 },
+                  borderRadius: "16px",
+                  borderBottomLeftRadius: "4px",
+                  boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+                  position: "relative",
+                }}
+              >
+                <Box
+                  component="p"
+                  sx={{
+                    fontSize: { xs: "12px", sm: "14px" },
+                    lineHeight: 1.6,
+                    margin: 0,
+                  }}
+                >
+                  Hello, brave explorer! 🌟
+                  <br />
+                  Welcome to TaleTree! Share your magical stories and ideas with
+                  me.
+                  <br />
+                  <br />
+                  Let's create something amazing together!
+                </Box>
+                {/* Speech bubble tail pointing to companion */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    bottom: 0,
+                    left: { xs: "8px", sm: "12px" },
+                    width: 0,
+                    height: 0,
+                    borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                    borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                    borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                    transform: "translateY(100%)",
+                  }}
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/client/components/signup-mui/MuiSignupChatContainer.jsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.jsx
@@ -56,8 +56,8 @@ export function MuiSignupChatContainer({
           key={message.id}
           sx={{
             position: "absolute",
-            bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-            left: { xs: "20%", sm: "25%", md: "30%", lg: "35%" },
+            bottom: { xs: "200px", sm: "240px", md: "280px", lg: "320px" },
+            left: { xs: "25%", sm: "30%", md: "35%", lg: "40%" },
             transform: "translateX(-50%)",
             zIndex: 10,
             animation: "slideInLeft 0.6s ease-out",
@@ -326,8 +326,8 @@ export function MuiSignupChatContainer({
           <Box
             sx={{
               position: "absolute",
-              bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-              left: { xs: "20%", sm: "25%", md: "30%", lg: "35%" },
+              bottom: { xs: "200px", sm: "240px", md: "280px", lg: "320px" },
+            left: { xs: "25%", sm: "30%", md: "35%", lg: "40%" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}

--- a/client/components/signup-mui/MuiSignupChatContainer.jsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.jsx
@@ -2,10 +2,7 @@ import { useState, useEffect } from "react";
 import { Box } from "@mui/material";
 import Lottie from "lottie-react";
 
-export function MuiSignupChatContainer({
-  messages,
-  isAIThinking = false,
-}) {
+export function MuiSignupChatContainer({ messages, isAIThinking = false }) {
   // State for Lottie animation data
   const [animationData, setAnimationData] = useState(null);
 
@@ -103,9 +100,18 @@ export function MuiSignupChatContainer({
                   left: { xs: "8px", sm: "12px" },
                   width: 0,
                   height: 0,
-                  borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                  borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                  borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                  borderLeft: {
+                    xs: "4px solid transparent",
+                    sm: "8px solid transparent",
+                  },
+                  borderRight: {
+                    xs: "4px solid transparent",
+                    sm: "8px solid transparent",
+                  },
+                  borderTop: {
+                    xs: "4px solid #3b82f6",
+                    sm: "8px solid #3b82f6",
+                  },
                   transform: "translateY(100%)",
                 }}
               />
@@ -179,7 +185,14 @@ export function MuiSignupChatContainer({
   };
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", height: "100%", position: "relative" }}>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        position: "relative",
+      }}
+    >
       {/* Fixed Companion Character on left side above chat input and on ground - responsive */}
       <Box
         sx={{
@@ -207,7 +220,8 @@ export function MuiSignupChatContainer({
               position: "absolute",
               inset: 0,
               borderRadius: "50%",
-              background: "radial-gradient(circle, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))",
+              background:
+                "radial-gradient(circle, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))",
               filter: "blur(40px)",
               animation: "pulse 2s infinite",
             }}
@@ -327,7 +341,7 @@ export function MuiSignupChatContainer({
             sx={{
               position: "absolute",
               bottom: { xs: "200px", sm: "240px", md: "280px", lg: "320px" },
-            left: { xs: "25%", sm: "30%", md: "35%", lg: "40%" },
+              left: { xs: "25%", sm: "30%", md: "35%", lg: "40%" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}
@@ -368,9 +382,18 @@ export function MuiSignupChatContainer({
                     left: { xs: "8px", sm: "12px" },
                     width: 0,
                     height: 0,
-                    borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                    borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                    borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                    borderLeft: {
+                      xs: "4px solid transparent",
+                      sm: "8px solid transparent",
+                    },
+                    borderRight: {
+                      xs: "4px solid transparent",
+                      sm: "8px solid transparent",
+                    },
+                    borderTop: {
+                      xs: "4px solid #3b82f6",
+                      sm: "8px solid #3b82f6",
+                    },
                     transform: "translateY(100%)",
                   }}
                 />

--- a/client/components/signup-mui/MuiSignupChatContainer.jsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.jsx
@@ -184,8 +184,8 @@ export function MuiSignupChatContainer({
       <Box
         sx={{
           position: "absolute",
-          bottom: { xs: 64, sm: 80, md: 96 },
-          left: { xs: "5%", sm: "8%", md: "12%", lg: "15%" },
+          bottom: { xs: 40, sm: 60, md: 80 },
+          left: { xs: "8%", sm: "10%", md: "15%", lg: "20%" },
           transform: "translateX(0)",
           zIndex: 10,
           transition: "transform 0.3s ease",

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -70,7 +70,7 @@ export function MuiSignupChatContainer({
           sx={{
             position: "absolute",
             bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-            left: { xs: "200px", sm: "250px", md: "300px", lg: "400px" },
+            left: { xs: "150px", sm: "200px", md: "250px", lg: "300px" },
             transform: "translateX(-50%)",
             zIndex: 10,
             animation: "slideInLeft 0.6s ease-out",
@@ -340,7 +340,7 @@ export function MuiSignupChatContainer({
             sx={{
               position: "absolute",
               bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-              left: { xs: "200px", sm: "250px", md: "300px", lg: "400px" },
+              left: { xs: "150px", sm: "200px", md: "250px", lg: "300px" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -1,0 +1,399 @@
+import { useState, useEffect } from "react";
+import { Box } from "@mui/material";
+import Lottie from "lottie-react";
+
+interface ChatMessage {
+  id: string;
+  type: "text" | "system";
+  sender: "AI" | "Kid";
+  content?: string;
+  timestamp: Date;
+}
+
+interface MuiSignupChatContainerProps {
+  messages: ChatMessage[];
+  isAIThinking?: boolean;
+}
+
+export function MuiSignupChatContainer({
+  messages,
+  isAIThinking = false,
+}: MuiSignupChatContainerProps) {
+  // State for Lottie animation data
+  const [animationData, setAnimationData] = useState(null);
+
+  // Load Lottie animation data
+  useEffect(() => {
+    const loadAnimation = async () => {
+      try {
+        const response = await fetch(
+          "https://cdn.builder.io/o/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2Faf1bb45b193d45099ddf3851679da168?alt=media&token=e1de5c73-b4dc-4ba8-add2-191d7b69446e&apiKey=da24af11bdbb4585b8e6eb6406b2daf9",
+        );
+        const data = await response.json();
+        setAnimationData(data);
+      } catch (error) {
+        console.error("Failed to load Lottie animation:", error);
+      }
+    };
+
+    loadAnimation();
+  }, []);
+
+  // Get the latest AI and Kid messages separately
+  const getLatestMessages = () => {
+    let latestAI = null;
+    let latestKid = null;
+
+    // Find the most recent AI and Kid messages
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message.sender === "AI" && !latestAI) {
+        latestAI = message;
+      }
+      if (message.sender === "Kid" && !latestKid) {
+        latestKid = message;
+      }
+      if (latestAI && latestKid) break;
+    }
+
+    return { latestAI, latestKid };
+  };
+
+  const { latestAI, latestKid } = getLatestMessages();
+
+  const renderMessage = (message: ChatMessage) => {
+    // AI text messages - positioned at companion mouth level
+    if (message.sender === "AI") {
+      return (
+        <Box
+          key={message.id}
+          sx={{
+            position: "absolute",
+            bottom: { xs: "224px", sm: "288px", md: "320px", lg: "384px" },
+            left: { xs: "60%", sm: "66.67%", md: "60%", lg: "60%" },
+            transform: "translateX(-50%)",
+            zIndex: 10,
+            animation: "slideInLeft 0.6s ease-out",
+            "@keyframes slideInLeft": {
+              "0%": {
+                opacity: 0,
+                transform: "translateX(-70px) scale(0.95)",
+              },
+              "100%": {
+                opacity: 1,
+                transform: "translateX(-50%) scale(1)",
+              },
+            },
+          }}
+        >
+          <Box sx={{ maxWidth: { xs: "300px", sm: "384px", md: "448px" } }}>
+            <Box
+              sx={{
+                bgcolor: "#3b82f6",
+                color: "white",
+                p: { xs: 1, sm: 1.5 },
+                borderRadius: "16px",
+                borderBottomLeftRadius: "4px",
+                boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+                position: "relative",
+              }}
+            >
+              <Box
+                component="p"
+                sx={{
+                  fontSize: { xs: "12px", sm: "14px" },
+                  lineHeight: 1.6,
+                  margin: 0,
+                }}
+              >
+                {message.content}
+              </Box>
+              {/* Speech bubble tail pointing to companion */}
+              <Box
+                sx={{
+                  position: "absolute",
+                  bottom: 0,
+                  left: { xs: "16px", sm: "24px" },
+                  width: 0,
+                  height: 0,
+                  borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                  borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                  borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                  transform: "translateY(100%)",
+                }}
+              />
+            </Box>
+          </Box>
+        </Box>
+      );
+    }
+
+    // Kid messages - positioned below AI message on the right
+    return (
+      <Box
+        key={message.id}
+        sx={{
+          position: "absolute",
+          bottom: "112px",
+          right: "32px",
+          animation: "slideInRight 0.6s ease-out",
+          "@keyframes slideInRight": {
+            "0%": {
+              opacity: 0,
+              transform: "translateX(20px) scale(0.95)",
+            },
+            "100%": {
+              opacity: 1,
+              transform: "translateX(0) scale(1)",
+            },
+          },
+        }}
+      >
+        <Box sx={{ maxWidth: "300px" }}>
+          <Box
+            sx={{
+              bgcolor: "#22c55e",
+              color: "white",
+              p: 1.5,
+              borderRadius: "16px",
+              borderBottomRightRadius: "4px",
+              boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+              position: "relative",
+            }}
+          >
+            <Box
+              component="p"
+              sx={{
+                fontSize: "14px",
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {message.content}
+            </Box>
+            {/* Speech bubble tail */}
+            <Box
+              sx={{
+                position: "absolute",
+                bottom: 0,
+                right: "16px",
+                width: 0,
+                height: 0,
+                borderLeft: "8px solid transparent",
+                borderRight: "8px solid transparent",
+                borderTop: "8px solid #22c55e",
+                transform: "translateY(100%)",
+              }}
+            />
+          </Box>
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%", position: "relative" }}>
+      {/* Fixed Companion Character on left side above chat input and on ground - responsive */}
+      <Box
+        sx={{
+          position: "absolute",
+          bottom: { xs: 64, sm: 80, md: 96 },
+          left: "25%",
+          transform: "translateX(-50%)",
+          zIndex: 10,
+          transition: "transform 0.3s ease",
+          "&:hover": {
+            transform: "translateX(-50%) scale(1.05)",
+          },
+        }}
+      >
+        <Box
+          sx={{
+            width: { xs: 192, sm: 256, md: 320, lg: 384 },
+            height: { xs: 192, sm: 256, md: 320, lg: 384 },
+            position: "relative",
+          }}
+        >
+          {/* Magical glow effect */}
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              borderRadius: "50%",
+              background: "radial-gradient(circle, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))",
+              filter: "blur(40px)",
+              animation: "pulse 2s infinite",
+            }}
+          />
+          {animationData ? (
+            <Lottie
+              animationData={animationData}
+              loop={true}
+              autoplay={true}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "contain",
+                filter: "drop-shadow(0 0 20px rgba(255, 255, 255, 0.3))",
+                position: "relative",
+                zIndex: 10,
+              }}
+            />
+          ) : (
+            // Fallback image while loading
+            <Box
+              component="img"
+              src="https://cdn.builder.io/api/v1/image/assets%2Fda24af11bdbb4585b8e6eb6406b2daf9%2F39f348f7483547d18b45c8bfcdc8ad42?format=webp&width=800"
+              alt="AI Companion"
+              sx={{
+                width: "100%",
+                height: "100%",
+                objectFit: "contain",
+                filter: "drop-shadow(0 0 20px rgba(255, 255, 255, 0.3))",
+                position: "relative",
+                zIndex: 10,
+                animation: "gentleFloat 4s ease-in-out infinite",
+                "@keyframes gentleFloat": {
+                  "0%, 100%": {
+                    transform: "translateY(0px) rotate(0deg)",
+                  },
+                  "25%": {
+                    transform: "translateY(-10px) rotate(1deg)",
+                  },
+                  "50%": {
+                    transform: "translateY(-15px) rotate(0deg)",
+                  },
+                  "75%": {
+                    transform: "translateY(-5px) rotate(-1deg)",
+                  },
+                },
+              }}
+            />
+          )}
+        </Box>
+        {isAIThinking && (
+          <Box
+            sx={{
+              position: "absolute",
+              top: -48,
+              left: "50%",
+              transform: "translateX(-50%)",
+              animation: "bounce 1s infinite",
+            }}
+          >
+            <Box
+              sx={{
+                bgcolor: "#3b82f6",
+                color: "white",
+                px: 2,
+                py: 1,
+                borderRadius: "20px",
+                fontSize: "14px",
+                boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                    animation: "pulse 1.5s infinite",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                    animation: "pulse 1.5s infinite 0.2s",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    bgcolor: "white",
+                    borderRadius: "50%",
+                    animation: "pulse 1.5s infinite 0.4s",
+                  }}
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {/* Messages Container - positioned absolutely for precise placement */}
+      <Box sx={{ position: "relative", width: "100%", height: "100%" }}>
+        {/* Latest AI Message - above companion */}
+        {latestAI && renderMessage(latestAI)}
+
+        {/* Latest Kid Message - on the right */}
+        {latestKid && renderMessage(latestKid)}
+
+        {/* Default state when no messages */}
+        {!latestAI && !latestKid && (
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: { xs: "224px", sm: "288px", md: "320px", lg: "384px" },
+              left: { xs: "60%", sm: "66.67%", md: "60%", lg: "60%" },
+              transform: "translateX(-50%)",
+              zIndex: 10,
+            }}
+          >
+            <Box sx={{ maxWidth: { xs: "300px", sm: "384px", md: "448px" } }}>
+              <Box
+                sx={{
+                  bgcolor: "#3b82f6",
+                  color: "white",
+                  p: { xs: 1, sm: 1.5 },
+                  borderRadius: "16px",
+                  borderBottomLeftRadius: "4px",
+                  boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+                  position: "relative",
+                }}
+              >
+                <Box
+                  component="p"
+                  sx={{
+                    fontSize: { xs: "12px", sm: "14px" },
+                    lineHeight: 1.6,
+                    margin: 0,
+                  }}
+                >
+                  Hello, brave explorer! 🌟
+                  <br />
+                  Welcome to TaleTree! Share your magical stories and ideas with
+                  me.
+                  <br />
+                  <br />
+                  Let's create something amazing together!
+                </Box>
+                {/* Speech bubble tail pointing to companion */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    bottom: 0,
+                    left: { xs: "16px", sm: "24px" },
+                    width: 0,
+                    height: 0,
+                    borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                    borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
+                    borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                    transform: "translateY(100%)",
+                  }}
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export type { ChatMessage };

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -198,7 +198,7 @@ export function MuiSignupChatContainer({
         sx={{
           position: "absolute",
           bottom: { xs: 64, sm: 80, md: 96 },
-          left: { xs: "150px", sm: "200px", md: "300px", lg: "400px" },
+          left: { xs: "5%", sm: "8%", md: "12%", lg: "15%" },
           transform: "translateX(0)",
           zIndex: 10,
           transition: "transform 0.3s ease",

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -198,7 +198,7 @@ export function MuiSignupChatContainer({
         sx={{
           position: "absolute",
           bottom: { xs: 64, sm: 80, md: 96 },
-          left: { xs: "100px", sm: "120px", md: "150px", lg: "200px" },
+          left: { xs: "50px", sm: "80px", md: "120px", lg: "150px" },
           transform: "translateX(0)",
           zIndex: 10,
           transition: "transform 0.3s ease",

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -198,7 +198,7 @@ export function MuiSignupChatContainer({
         sx={{
           position: "absolute",
           bottom: { xs: 64, sm: 80, md: 96 },
-          left: { xs: "80px", sm: "120px", md: "180px", lg: "250px" },
+          left: { xs: "150px", sm: "200px", md: "300px", lg: "400px" },
           transform: "translateX(0)",
           zIndex: 10,
           transition: "transform 0.3s ease",

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -69,8 +69,8 @@ export function MuiSignupChatContainer({
           key={message.id}
           sx={{
             position: "absolute",
-            bottom: { xs: "224px", sm: "288px", md: "320px", lg: "384px" },
-            left: { xs: "60%", sm: "66.67%", md: "60%", lg: "60%" },
+            bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
+            left: { xs: "35%", sm: "40%", md: "42%", lg: "44%" },
             transform: "translateX(-50%)",
             zIndex: 10,
             animation: "slideInLeft 0.6s ease-out",

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -70,7 +70,7 @@ export function MuiSignupChatContainer({
           sx={{
             position: "absolute",
             bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-            left: { xs: "35%", sm: "40%", md: "42%", lg: "44%" },
+            left: { xs: "200px", sm: "250px", md: "300px", lg: "400px" },
             transform: "translateX(-50%)",
             zIndex: 10,
             animation: "slideInLeft 0.6s ease-out",
@@ -340,7 +340,7 @@ export function MuiSignupChatContainer({
             sx={{
               position: "absolute",
               bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-              left: { xs: "35%", sm: "40%", md: "42%", lg: "44%" },
+              left: { xs: "200px", sm: "250px", md: "300px", lg: "400px" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -339,8 +339,8 @@ export function MuiSignupChatContainer({
           <Box
             sx={{
               position: "absolute",
-              bottom: { xs: "224px", sm: "288px", md: "320px", lg: "384px" },
-              left: { xs: "60%", sm: "66.67%", md: "60%", lg: "60%" },
+              bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
+              left: { xs: "35%", sm: "40%", md: "42%", lg: "44%" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -198,12 +198,12 @@ export function MuiSignupChatContainer({
         sx={{
           position: "absolute",
           bottom: { xs: 64, sm: 80, md: 96 },
-          left: { xs: "15%", sm: "18%", md: "20%", lg: "22%" },
-          transform: "translateX(-50%)",
+          left: { xs: "100px", sm: "120px", md: "150px", lg: "200px" },
+          transform: "translateX(0)",
           zIndex: 10,
           transition: "transform 0.3s ease",
           "&:hover": {
-            transform: "translateX(-50%) scale(1.05)",
+            transform: "scale(1.05)",
           },
         }}
       >

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -70,7 +70,7 @@ export function MuiSignupChatContainer({
           sx={{
             position: "absolute",
             bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-            left: { xs: "150px", sm: "200px", md: "250px", lg: "300px" },
+            left: { xs: "250px", sm: "300px", md: "400px", lg: "500px" },
             transform: "translateX(-50%)",
             zIndex: 10,
             animation: "slideInLeft 0.6s ease-out",
@@ -340,7 +340,7 @@ export function MuiSignupChatContainer({
             sx={{
               position: "absolute",
               bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-              left: { xs: "150px", sm: "200px", md: "250px", lg: "300px" },
+              left: { xs: "250px", sm: "300px", md: "400px", lg: "500px" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -198,7 +198,7 @@ export function MuiSignupChatContainer({
         sx={{
           position: "absolute",
           bottom: { xs: 64, sm: 80, md: 96 },
-          left: "25%",
+          left: { xs: "15%", sm: "18%", md: "20%", lg: "22%" },
           transform: "translateX(-50%)",
           zIndex: 10,
           transition: "transform 0.3s ease",

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -70,7 +70,7 @@ export function MuiSignupChatContainer({
           sx={{
             position: "absolute",
             bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-            left: { xs: "320px", sm: "400px", md: "520px", lg: "650px" },
+            left: { xs: "20%", sm: "25%", md: "30%", lg: "35%" },
             transform: "translateX(-50%)",
             zIndex: 10,
             animation: "slideInLeft 0.6s ease-out",
@@ -340,7 +340,7 @@ export function MuiSignupChatContainer({
             sx={{
               position: "absolute",
               bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-              left: { xs: "320px", sm: "400px", md: "520px", lg: "650px" },
+              left: { xs: "20%", sm: "25%", md: "30%", lg: "35%" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -116,9 +116,18 @@ export function MuiSignupChatContainer({
                   left: { xs: "8px", sm: "12px" },
                   width: 0,
                   height: 0,
-                  borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                  borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                  borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                  borderLeft: {
+                    xs: "4px solid transparent",
+                    sm: "8px solid transparent",
+                  },
+                  borderRight: {
+                    xs: "4px solid transparent",
+                    sm: "8px solid transparent",
+                  },
+                  borderTop: {
+                    xs: "4px solid #3b82f6",
+                    sm: "8px solid #3b82f6",
+                  },
                   transform: "translateY(100%)",
                 }}
               />
@@ -192,7 +201,14 @@ export function MuiSignupChatContainer({
   };
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", height: "100%", position: "relative" }}>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        position: "relative",
+      }}
+    >
       {/* Fixed Companion Character on left side above chat input and on ground - responsive */}
       <Box
         sx={{
@@ -220,7 +236,8 @@ export function MuiSignupChatContainer({
               position: "absolute",
               inset: 0,
               borderRadius: "50%",
-              background: "radial-gradient(circle, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))",
+              background:
+                "radial-gradient(circle, rgba(168, 85, 247, 0.2), rgba(236, 72, 153, 0.2))",
               filter: "blur(40px)",
               animation: "pulse 2s infinite",
             }}
@@ -381,9 +398,18 @@ export function MuiSignupChatContainer({
                     left: { xs: "8px", sm: "12px" },
                     width: 0,
                     height: 0,
-                    borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                    borderRight: { xs: "4px solid transparent", sm: "8px solid transparent" },
-                    borderTop: { xs: "4px solid #3b82f6", sm: "8px solid #3b82f6" },
+                    borderLeft: {
+                      xs: "4px solid transparent",
+                      sm: "8px solid transparent",
+                    },
+                    borderRight: {
+                      xs: "4px solid transparent",
+                      sm: "8px solid transparent",
+                    },
+                    borderTop: {
+                      xs: "4px solid #3b82f6",
+                      sm: "8px solid #3b82f6",
+                    },
                     transform: "translateY(100%)",
                   }}
                 />

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -70,7 +70,7 @@ export function MuiSignupChatContainer({
           sx={{
             position: "absolute",
             bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-            left: { xs: "250px", sm: "300px", md: "400px", lg: "500px" },
+            left: { xs: "320px", sm: "400px", md: "520px", lg: "650px" },
             transform: "translateX(-50%)",
             zIndex: 10,
             animation: "slideInLeft 0.6s ease-out",
@@ -340,7 +340,7 @@ export function MuiSignupChatContainer({
             sx={{
               position: "absolute",
               bottom: { xs: "280px", sm: "350px", md: "400px", lg: "450px" },
-              left: { xs: "250px", sm: "300px", md: "400px", lg: "500px" },
+              left: { xs: "320px", sm: "400px", md: "520px", lg: "650px" },
               transform: "translateX(-50%)",
               zIndex: 10,
             }}

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -113,7 +113,7 @@ export function MuiSignupChatContainer({
                 sx={{
                   position: "absolute",
                   bottom: 0,
-                  left: { xs: "16px", sm: "24px" },
+                  left: { xs: "8px", sm: "12px" },
                   width: 0,
                   height: 0,
                   borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },
@@ -378,7 +378,7 @@ export function MuiSignupChatContainer({
                   sx={{
                     position: "absolute",
                     bottom: 0,
-                    left: { xs: "16px", sm: "24px" },
+                    left: { xs: "8px", sm: "12px" },
                     width: 0,
                     height: 0,
                     borderLeft: { xs: "4px solid transparent", sm: "8px solid transparent" },

--- a/client/components/signup-mui/MuiSignupChatContainer.tsx
+++ b/client/components/signup-mui/MuiSignupChatContainer.tsx
@@ -198,7 +198,7 @@ export function MuiSignupChatContainer({
         sx={{
           position: "absolute",
           bottom: { xs: 64, sm: 80, md: 96 },
-          left: { xs: "50px", sm: "80px", md: "120px", lg: "150px" },
+          left: { xs: "80px", sm: "120px", md: "180px", lg: "250px" },
           transform: "translateX(0)",
           zIndex: 10,
           transition: "transform 0.3s ease",

--- a/client/components/signup-mui/MuiSignupChatInput.jsx
+++ b/client/components/signup-mui/MuiSignupChatInput.jsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { Box, IconButton, TextField } from "@mui/material";
+import { ArrowUpward, Mic } from "@mui/icons-material";
+
+export function MuiSignupChatInput({
+  onSendMessage,
+  placeholder = "Ask me anything...",
+  disabled = false,
+}) {
+  const [message, setMessage] = useState("");
+
+  const handleSend = () => {
+    if (message.trim() && onSendMessage) {
+      onSendMessage(message.trim());
+      setMessage("");
+    }
+  };
+
+  const handleKeyPress = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <Box sx={{ width: "95%", maxWidth: "none", mx: "auto", px: 1 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          bgcolor: "white",
+          borderRadius: "25px",
+          boxShadow: "0px 6px 24px rgba(0, 0, 0, 0.12)",
+          border: "1px solid #e5e7eb",
+          px: 1.5,
+          py: 1,
+        }}
+      >
+        {/* Text Input */}
+        <Box sx={{ flex: 1, position: "relative" }}>
+          <TextField
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder={placeholder}
+            disabled={disabled}
+            variant="standard"
+            fullWidth
+            sx={{
+              "& .MuiInput-underline:before": {
+                borderBottom: "none",
+              },
+              "& .MuiInput-underline:after": {
+                borderBottom: "none",
+              },
+              "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+                borderBottom: "none",
+              },
+              "& .MuiInputBase-input": {
+                padding: "8px 12px",
+                color: "#374151",
+                fontSize: "14px",
+                "&::placeholder": {
+                  color: "#6b7280",
+                  opacity: 1,
+                },
+              },
+            }}
+          />
+        </Box>
+
+        {/* Microphone Button */}
+        <IconButton
+          disabled={disabled}
+          sx={{
+            width: 36,
+            height: 36,
+            bgcolor: "#f3f4f6",
+            "&:hover": {
+              bgcolor: "#e5e7eb",
+            },
+            transition: "all 0.2s ease",
+          }}
+        >
+          <Mic sx={{ width: 16, height: 16, color: "#4b5563" }} />
+        </IconButton>
+
+        {/* Send Button */}
+        <IconButton
+          onClick={handleSend}
+          disabled={disabled || !message.trim()}
+          sx={{
+            width: 36,
+            height: 36,
+            background: message.trim()
+              ? "linear-gradient(135deg, #4FC3F7 0%, #29B6F6 100%)"
+              : "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
+            opacity: !message.trim() ? 0.6 : 1,
+            transition: "all 0.2s ease",
+            "&:hover": {
+              transform: "scale(1.1)",
+              background: message.trim()
+                ? "linear-gradient(135deg, #29B6F6 0%, #1976D2 100%)"
+                : "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
+            },
+            "&:disabled": {
+              background: "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
+            },
+          }}
+        >
+          <ArrowUpward sx={{ width: 16, height: 16, color: "white" }} />
+        </IconButton>
+      </Box>
+    </Box>
+  );
+}

--- a/client/components/signup-mui/MuiSignupChatInput.tsx
+++ b/client/components/signup-mui/MuiSignupChatInput.tsx
@@ -30,7 +30,7 @@ export function MuiSignupChatInput({
   };
 
   return (
-    <Box sx={{ width: "100%", maxWidth: "90rem", mx: "auto", px: 1 }}>
+    <Box sx={{ width: "95%", maxWidth: "none", mx: "auto", px: 1 }}>
       <Box
         sx={{
           display: "flex",

--- a/client/components/signup-mui/MuiSignupChatInput.tsx
+++ b/client/components/signup-mui/MuiSignupChatInput.tsx
@@ -30,7 +30,7 @@ export function MuiSignupChatInput({
   };
 
   return (
-    <Box sx={{ width: "100%", maxWidth: "80rem", mx: "auto", px: 2 }}>
+    <Box sx={{ width: "100%", maxWidth: "90rem", mx: "auto", px: 1 }}>
       <Box
         sx={{
           display: "flex",

--- a/client/components/signup-mui/MuiSignupChatInput.tsx
+++ b/client/components/signup-mui/MuiSignupChatInput.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { Box, IconButton, TextField } from "@mui/material";
+import { ArrowUpward, Mic } from "@mui/icons-material";
+
+interface MuiSignupChatInputProps {
+  onSendMessage?: (message: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export function MuiSignupChatInput({
+  onSendMessage,
+  placeholder = "Ask me anything...",
+  disabled = false,
+}: MuiSignupChatInputProps) {
+  const [message, setMessage] = useState("");
+
+  const handleSend = () => {
+    if (message.trim() && onSendMessage) {
+      onSendMessage(message.trim());
+      setMessage("");
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <Box sx={{ width: "100%", maxWidth: "64rem", mx: "auto", px: 2 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          bgcolor: "white",
+          borderRadius: "25px",
+          boxShadow: "0px 6px 24px rgba(0, 0, 0, 0.12)",
+          border: "1px solid #e5e7eb",
+          px: 1.5,
+          py: 1,
+        }}
+      >
+        {/* Text Input */}
+        <Box sx={{ flex: 1, position: "relative" }}>
+          <TextField
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder={placeholder}
+            disabled={disabled}
+            variant="standard"
+            fullWidth
+            sx={{
+              "& .MuiInput-underline:before": {
+                borderBottom: "none",
+              },
+              "& .MuiInput-underline:after": {
+                borderBottom: "none",
+              },
+              "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+                borderBottom: "none",
+              },
+              "& .MuiInputBase-input": {
+                padding: "8px 12px",
+                color: "#374151",
+                fontSize: "14px",
+                "&::placeholder": {
+                  color: "#6b7280",
+                  opacity: 1,
+                },
+              },
+            }}
+          />
+        </Box>
+
+        {/* Microphone Button */}
+        <IconButton
+          disabled={disabled}
+          sx={{
+            width: 36,
+            height: 36,
+            bgcolor: "#f3f4f6",
+            "&:hover": {
+              bgcolor: "#e5e7eb",
+            },
+            transition: "all 0.2s ease",
+          }}
+        >
+          <Mic sx={{ width: 16, height: 16, color: "#4b5563" }} />
+        </IconButton>
+
+        {/* Send Button */}
+        <IconButton
+          onClick={handleSend}
+          disabled={disabled || !message.trim()}
+          sx={{
+            width: 36,
+            height: 36,
+            background: message.trim()
+              ? "linear-gradient(135deg, #4FC3F7 0%, #29B6F6 100%)"
+              : "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
+            opacity: !message.trim() ? 0.6 : 1,
+            transition: "all 0.2s ease",
+            "&:hover": {
+              transform: "scale(1.1)",
+              background: message.trim()
+                ? "linear-gradient(135deg, #29B6F6 0%, #1976D2 100%)"
+                : "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
+            },
+            "&:disabled": {
+              background: "linear-gradient(135deg, #E0E0E0 0%, #BDBDBD 100%)",
+            },
+          }}
+        >
+          <ArrowUpward sx={{ width: 16, height: 16, color: "white" }} />
+        </IconButton>
+      </Box>
+    </Box>
+  );
+}

--- a/client/components/signup-mui/MuiSignupChatInput.tsx
+++ b/client/components/signup-mui/MuiSignupChatInput.tsx
@@ -30,7 +30,7 @@ export function MuiSignupChatInput({
   };
 
   return (
-    <Box sx={{ width: "100%", maxWidth: "64rem", mx: "auto", px: 2 }}>
+    <Box sx={{ width: "100%", maxWidth: "80rem", mx: "auto", px: 2 }}>
       <Box
         sx={{
           display: "flex",

--- a/client/components/signup-mui/MuiSignupDualSidebar.jsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.jsx
@@ -131,7 +131,15 @@ export function MuiSignupDualSidebar({
       }}
     >
       {/* Container with zero margin, aligned to left edge */}
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, py: 2, overflow: "hidden" }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1.5,
+          py: 2,
+          overflow: "hidden",
+        }}
+      >
         {/* Top Sidebar Section */}
         <Box sx={{ position: "relative" }}>
           <Box
@@ -153,7 +161,14 @@ export function MuiSignupDualSidebar({
               }}
             >
               <Box sx={{ overflowY: "auto", maxHeight: "calc(60vh - 32px)" }}>
-                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 1.5,
+                  }}
+                >
                   {topMenuItems.map((item, index) => (
                     <Box
                       key={item.alt}
@@ -241,8 +256,6 @@ export function MuiSignupDualSidebar({
                 </Box>
               </Box>
             </Box>
-
-
           </Box>
         </Box>
 
@@ -267,7 +280,14 @@ export function MuiSignupDualSidebar({
               }}
             >
               <Box sx={{ overflowY: "auto", maxHeight: "calc(30vh - 24px)" }}>
-                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 1,
+                  }}
+                >
                   {dynamicBottomMenuItems.map((item, index) => (
                     <Box
                       key={item.alt}
@@ -276,7 +296,9 @@ export function MuiSignupDualSidebar({
                         animation: showBottomWaveEffect
                           ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
                           : "none",
-                        transform: showBottomWaveEffect ? "scale(1)" : "scale(0)",
+                        transform: showBottomWaveEffect
+                          ? "scale(1)"
+                          : "scale(0)",
                       }}
                     >
                       <Tooltip
@@ -331,8 +353,6 @@ export function MuiSignupDualSidebar({
                 </Box>
               </Box>
             </Box>
-
-
           </Box>
         </Box>
       </Box>

--- a/client/components/signup-mui/MuiSignupDualSidebar.jsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.jsx
@@ -1,0 +1,357 @@
+import { useState } from "react";
+import { Box, IconButton, Tooltip } from "@mui/material";
+import { ChevronLeft } from "@mui/icons-material";
+import { MuiTaleTreeWheelModal } from "./MuiTaleTreeWheelModal";
+import { MuiCompanionSelectionModal } from "./MuiCompanionSelectionModal";
+
+export function MuiSignupDualSidebar({
+  topMenuItems = [
+    {
+      src: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fcb34a17284254803ab9d0f3977ab5c38?format=webp&width=800",
+      alt: "Menu",
+      delay: 100,
+    },
+  ],
+  bottomMenuItems,
+  onMenuItemClick,
+}) {
+  const [topSidebarCollapsed, setTopSidebarCollapsed] = useState(false);
+  const [bottomSidebarCollapsed, setBottomSidebarCollapsed] = useState(false);
+  const [showTopWaveEffect, setShowTopWaveEffect] = useState(true);
+  const [showBottomWaveEffect, setShowBottomWaveEffect] = useState(true);
+  const [isWheelModalOpen, setIsWheelModalOpen] = useState(false);
+  const [isCompanionModalOpen, setIsCompanionModalOpen] = useState(false);
+  const [selectedCompanion, setSelectedCompanion] = useState({
+    id: "letsgo",
+    name: "Letsgo",
+    image:
+      "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
+  });
+
+  const toggleTopSidebar = () => {
+    setTopSidebarCollapsed(!topSidebarCollapsed);
+  };
+
+  const toggleBottomSidebar = () => {
+    setBottomSidebarCollapsed(!bottomSidebarCollapsed);
+  };
+
+  // Companion mapping
+  const companionMapping = {
+    letsgo: {
+      name: "Letsgo",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
+    },
+    rushmore: {
+      name: "Rushmore",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800",
+    },
+    uni: {
+      name: "Uni",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800",
+    },
+    cody: {
+      name: "Cody",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800",
+    },
+    doma: {
+      name: "Doma",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800",
+    },
+    rooty: {
+      name: "Rooty",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800",
+    },
+  };
+
+  const handleCompanionSelect = (companionId) => {
+    const companion = companionMapping[companionId];
+    if (companion) {
+      setSelectedCompanion({
+        id: companionId,
+        name: companion.name,
+        image: companion.image,
+      });
+    }
+  };
+
+  // Dynamic bottom menu items based on selected companion
+  const dynamicBottomMenuItems = bottomMenuItems || [
+    {
+      src: selectedCompanion.image,
+      alt: selectedCompanion.name,
+      delay: 100,
+    },
+  ];
+
+  const sidebarStyle = {
+    bgcolor: "#1C2051",
+    border: "1px solid rgba(255, 255, 255, 0.2)",
+    borderLeft: "none",
+    borderRadius: "0 15px 15px 0",
+    boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
+    transition: "all 0.5s ease-in-out",
+    position: "relative",
+  };
+
+  const menuItemStyle = {
+    width: 48,
+    height: 48,
+    borderRadius: "16px",
+    overflow: "hidden",
+    cursor: "pointer",
+    transition: "all 0.3s ease",
+    bgcolor: "rgba(255, 255, 255, 0.05)",
+    border: "1px solid rgba(255, 255, 255, 0.1)",
+    backdropFilter: "blur(8px)",
+    "&:hover": {
+      transform: "scale(1.1)",
+      boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)",
+      bgcolor: "rgba(255, 255, 255, 0.15)",
+      borderColor: "rgba(255, 255, 255, 0.3)",
+    },
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        left: 0,
+        top: 128,
+        zIndex: 30,
+        display: "flex",
+        flexDirection: "column",
+        width: "auto",
+      }}
+    >
+      {/* Container with zero margin, aligned to left edge */}
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, py: 2, overflow: "hidden" }}>
+        {/* Top Sidebar Section */}
+        <Box sx={{ position: "relative" }}>
+          <Box
+            sx={{
+              ...sidebarStyle,
+              width: 80,
+              height: "auto",
+              maxHeight: "calc(60vh)",
+            }}
+          >
+            {/* Menu Items */}
+            <Box
+              sx={{
+                transition: "all 0.5s ease-in-out",
+                overflow: "hidden",
+                width: 64,
+                opacity: 1,
+                p: 2,
+              }}
+            >
+              <Box sx={{ overflowY: "auto", maxHeight: "calc(60vh - 32px)" }}>
+                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5 }}>
+                  {topMenuItems.map((item, index) => (
+                    <Box
+                      key={item.alt}
+                      sx={{
+                        position: "relative",
+                        animation: showTopWaveEffect
+                          ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
+                          : "none",
+                        transform: showTopWaveEffect ? "scale(1)" : "scale(0)",
+                        "@keyframes popIn": {
+                          "0%": {
+                            transform: "scale(0) rotate(0deg)",
+                            opacity: 0,
+                          },
+                          "50%": {
+                            transform: "scale(1.2) rotate(5deg)",
+                          },
+                          "100%": {
+                            transform: "scale(1) rotate(0deg)",
+                            opacity: 1,
+                          },
+                        },
+                        "@keyframes wave": {
+                          "0%, 100%": {
+                            transform: "scale(1) translateY(0px)",
+                          },
+                          "25%": {
+                            transform: "scale(1.05) translateY(-2px)",
+                          },
+                          "50%": {
+                            transform: "scale(1) translateY(0px)",
+                          },
+                          "75%": {
+                            transform: "scale(1.05) translateY(2px)",
+                          },
+                        },
+                      }}
+                    >
+                      <Tooltip
+                        title={item.alt}
+                        placement="right"
+                        arrow
+                        sx={{
+                          "& .MuiTooltip-tooltip": {
+                            bgcolor: "#1C2051",
+                            border: "1px solid rgba(255, 255, 255, 0.2)",
+                            borderRadius: "12px",
+                            color: "white",
+                            fontSize: "12px",
+                            fontWeight: 500,
+                          },
+                          "& .MuiTooltip-arrow": {
+                            color: "#1C2051",
+                          },
+                        }}
+                      >
+                        <Box
+                          sx={menuItemStyle}
+                          onClick={() => {
+                            if (item.alt === "Menu") {
+                              setIsWheelModalOpen(true);
+                            } else {
+                              onMenuItemClick?.(item.alt, index);
+                            }
+                          }}
+                        >
+                          <Box
+                            component="img"
+                            src={item.src}
+                            alt={item.alt}
+                            sx={{
+                              width: "100%",
+                              height: "100%",
+                              objectFit: "cover",
+                              transition: "transform 0.3s ease",
+                              "&:hover": {
+                                transform: "rotate(12deg)",
+                              },
+                            }}
+                          />
+                        </Box>
+                      </Tooltip>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            </Box>
+
+
+          </Box>
+        </Box>
+
+        {/* Bottom Sidebar Section */}
+        <Box sx={{ position: "relative" }}>
+          <Box
+            sx={{
+              ...sidebarStyle,
+              width: 80,
+              height: "auto",
+              maxHeight: "calc(30vh)",
+            }}
+          >
+            {/* Menu Items */}
+            <Box
+              sx={{
+                transition: "all 0.5s ease-in-out",
+                overflow: "hidden",
+                width: 64,
+                opacity: 1,
+                p: 1.5,
+              }}
+            >
+              <Box sx={{ overflowY: "auto", maxHeight: "calc(30vh - 24px)" }}>
+                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
+                  {dynamicBottomMenuItems.map((item, index) => (
+                    <Box
+                      key={item.alt}
+                      sx={{
+                        position: "relative",
+                        animation: showBottomWaveEffect
+                          ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
+                          : "none",
+                        transform: showBottomWaveEffect ? "scale(1)" : "scale(0)",
+                      }}
+                    >
+                      <Tooltip
+                        title={item.alt}
+                        placement="right"
+                        arrow
+                        sx={{
+                          "& .MuiTooltip-tooltip": {
+                            bgcolor: "#1C2051",
+                            border: "1px solid rgba(255, 255, 255, 0.2)",
+                            borderRadius: "12px",
+                            color: "white",
+                            fontSize: "12px",
+                            fontWeight: 500,
+                          },
+                          "& .MuiTooltip-arrow": {
+                            color: "#1C2051",
+                          },
+                        }}
+                      >
+                        <Box
+                          sx={menuItemStyle}
+                          onClick={() => {
+                            if (
+                              item.alt === selectedCompanion.name ||
+                              item.alt === "Selected Companion"
+                            ) {
+                              setIsCompanionModalOpen(true);
+                            } else {
+                              onMenuItemClick?.(item.alt, index);
+                            }
+                          }}
+                        >
+                          <Box
+                            component="img"
+                            src={item.src}
+                            alt={item.alt}
+                            sx={{
+                              width: "100%",
+                              height: "100%",
+                              objectFit: "cover",
+                              transition: "transform 0.3s ease",
+                              "&:hover": {
+                                transform: "rotate(12deg)",
+                              },
+                            }}
+                          />
+                        </Box>
+                      </Tooltip>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            </Box>
+
+
+          </Box>
+        </Box>
+      </Box>
+
+      {/* TaleTree Wheel Modal */}
+      <MuiTaleTreeWheelModal
+        isOpen={isWheelModalOpen}
+        onClose={() => setIsWheelModalOpen(false)}
+      />
+
+      {/* Companion Selection Modal */}
+      <MuiCompanionSelectionModal
+        isOpen={isCompanionModalOpen}
+        onClose={() => setIsCompanionModalOpen(false)}
+        onSelectCompanion={(companionId) => {
+          handleCompanionSelect(companionId);
+          console.log("Selected companion:", companionId);
+        }}
+      />
+    </Box>
+  );
+}

--- a/client/components/signup-mui/MuiSignupDualSidebar.jsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Box, IconButton, Tooltip } from "@mui/material";
 import { ChevronLeft } from "@mui/icons-material";
-import { MuiTaleTreeWheelModal } from "./MuiTaleTreeWheelModal";
-import { MuiCompanionSelectionModal } from "./MuiCompanionSelectionModal";
+import { MuiTaleTreeWheelModal } from "./MuiTaleTreeWheelModal.jsx";
+import { MuiCompanionSelectionModal } from "./MuiCompanionSelectionModal.jsx";
 
 export function MuiSignupDualSidebar({
   topMenuItems = [

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -274,8 +274,8 @@ export function MuiSignupDualSidebar({
               sx={{
                 transition: "all 0.5s ease-in-out",
                 overflow: "hidden",
-                width: bottomSidebarCollapsed ? 0 : 64,
-                opacity: bottomSidebarCollapsed ? 0 : 1,
+                width: 64,
+                opacity: 1,
                 p: 1.5,
               }}
             >

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -345,50 +345,7 @@ export function MuiSignupDualSidebar({
               </Box>
             </Box>
 
-            {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
-            <Box
-              sx={{
-                position: "absolute",
-                right: 2,
-                top: "50%",
-                transform: "translateY(-50%)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <IconButton
-                onClick={toggleBottomSidebar}
-                sx={{
-                  width: 24,
-                  height: 32,
-                  bgcolor: "transparent",
-                  "&:hover": {
-                    bgcolor: "rgba(255, 255, 255, 0.1)",
-                    transform: "scale(1.1)",
-                  },
-                  borderRadius: "6px",
-                  transition: "all 0.3s ease",
-                  p: 0,
-                }}
-              >
-                <Box
-                  component="img"
-                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F7504875ba38348f8bb8df1ca5aaf3464?format=webp&width=800"
-                  alt="Toggle"
-                  sx={{
-                    width: 16,
-                    height: 16,
-                    objectFit: "contain",
-                    transition: "transform 0.3s ease",
-                    transform: bottomSidebarCollapsed ? "rotate(0deg)" : "rotate(180deg)",
-                    "&:hover": {
-                      transform: bottomSidebarCollapsed ? "scale(1.25)" : "rotate(180deg) scale(1.25)",
-                    },
-                  }}
-                />
-              </IconButton>
-            </Box>
+
           </Box>
         </Box>
       </Box>

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -160,8 +160,8 @@ export function MuiSignupDualSidebar({
               sx={{
                 transition: "all 0.5s ease-in-out",
                 overflow: "hidden",
-                width: topSidebarCollapsed ? 0 : 64,
-                opacity: topSidebarCollapsed ? 0 : 1,
+                width: 64,
+                opacity: 1,
                 p: 2,
               }}
             >

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -150,7 +150,7 @@ export function MuiSignupDualSidebar({
           <Box
             sx={{
               ...sidebarStyle,
-              width: topSidebarCollapsed ? 32 : 80,
+              width: 80,
               height: "auto",
               maxHeight: "calc(60vh)",
             }}

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -255,50 +255,7 @@ export function MuiSignupDualSidebar({
               </Box>
             </Box>
 
-            {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
-            <Box
-              sx={{
-                position: "absolute",
-                right: 2,
-                top: "50%",
-                transform: "translateY(-50%)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <IconButton
-                onClick={toggleTopSidebar}
-                sx={{
-                  width: 24,
-                  height: 32,
-                  bgcolor: "transparent",
-                  "&:hover": {
-                    bgcolor: "rgba(255, 255, 255, 0.1)",
-                    transform: "scale(1.1)",
-                  },
-                  borderRadius: "6px",
-                  transition: "all 0.3s ease",
-                  p: 0,
-                }}
-              >
-                <Box
-                  component="img"
-                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F7504875ba38348f8bb8df1ca5aaf3464?format=webp&width=800"
-                  alt="Toggle"
-                  sx={{
-                    width: 16,
-                    height: 16,
-                    objectFit: "contain",
-                    transition: "transform 0.3s ease",
-                    transform: topSidebarCollapsed ? "rotate(0deg)" : "rotate(180deg)",
-                    "&:hover": {
-                      transform: topSidebarCollapsed ? "scale(1.25)" : "rotate(180deg) scale(1.25)",
-                    },
-                  }}
-                />
-              </IconButton>
-            </Box>
+
           </Box>
         </Box>
 

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -144,7 +144,15 @@ export function MuiSignupDualSidebar({
       }}
     >
       {/* Container with zero margin, aligned to left edge */}
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, py: 2, overflow: "hidden" }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1.5,
+          py: 2,
+          overflow: "hidden",
+        }}
+      >
         {/* Top Sidebar Section */}
         <Box sx={{ position: "relative" }}>
           <Box
@@ -166,7 +174,14 @@ export function MuiSignupDualSidebar({
               }}
             >
               <Box sx={{ overflowY: "auto", maxHeight: "calc(60vh - 32px)" }}>
-                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 1.5,
+                  }}
+                >
                   {topMenuItems.map((item, index) => (
                     <Box
                       key={item.alt}
@@ -254,8 +269,6 @@ export function MuiSignupDualSidebar({
                 </Box>
               </Box>
             </Box>
-
-
           </Box>
         </Box>
 
@@ -280,7 +293,14 @@ export function MuiSignupDualSidebar({
               }}
             >
               <Box sx={{ overflowY: "auto", maxHeight: "calc(30vh - 24px)" }}>
-                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 1,
+                  }}
+                >
                   {dynamicBottomMenuItems.map((item, index) => (
                     <Box
                       key={item.alt}
@@ -289,7 +309,9 @@ export function MuiSignupDualSidebar({
                         animation: showBottomWaveEffect
                           ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
                           : "none",
-                        transform: showBottomWaveEffect ? "scale(1)" : "scale(0)",
+                        transform: showBottomWaveEffect
+                          ? "scale(1)"
+                          : "scale(0)",
                       }}
                     >
                       <Tooltip
@@ -344,8 +366,6 @@ export function MuiSignupDualSidebar({
                 </Box>
               </Box>
             </Box>
-
-
           </Box>
         </Box>
       </Box>

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -264,7 +264,7 @@ export function MuiSignupDualSidebar({
           <Box
             sx={{
               ...sidebarStyle,
-              width: bottomSidebarCollapsed ? 32 : 80,
+              width: 80,
               height: "auto",
               maxHeight: "calc(30vh)",
             }}

--- a/client/components/signup-mui/MuiSignupDualSidebar.tsx
+++ b/client/components/signup-mui/MuiSignupDualSidebar.tsx
@@ -1,0 +1,456 @@
+import { useState } from "react";
+import { Box, IconButton, Tooltip } from "@mui/material";
+import { ChevronLeft } from "@mui/icons-material";
+import { MuiTaleTreeWheelModal } from "./MuiTaleTreeWheelModal";
+import { MuiCompanionSelectionModal } from "./MuiCompanionSelectionModal";
+
+interface MenuItem {
+  src: string;
+  alt: string;
+  delay: number;
+}
+
+interface MuiSignupDualSidebarProps {
+  topMenuItems?: MenuItem[];
+  bottomMenuItems?: MenuItem[];
+  onMenuItemClick?: (itemAlt: string, index: number) => void;
+}
+
+export function MuiSignupDualSidebar({
+  topMenuItems = [
+    {
+      src: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fcb34a17284254803ab9d0f3977ab5c38?format=webp&width=800",
+      alt: "Menu",
+      delay: 100,
+    },
+  ],
+  bottomMenuItems,
+  onMenuItemClick,
+}: MuiSignupDualSidebarProps) {
+  const [topSidebarCollapsed, setTopSidebarCollapsed] = useState(false);
+  const [bottomSidebarCollapsed, setBottomSidebarCollapsed] = useState(false);
+  const [showTopWaveEffect, setShowTopWaveEffect] = useState(true);
+  const [showBottomWaveEffect, setShowBottomWaveEffect] = useState(true);
+  const [isWheelModalOpen, setIsWheelModalOpen] = useState(false);
+  const [isCompanionModalOpen, setIsCompanionModalOpen] = useState(false);
+  const [selectedCompanion, setSelectedCompanion] = useState({
+    id: "letsgo",
+    name: "Letsgo",
+    image:
+      "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
+  });
+
+  const toggleTopSidebar = () => {
+    setTopSidebarCollapsed(!topSidebarCollapsed);
+  };
+
+  const toggleBottomSidebar = () => {
+    setBottomSidebarCollapsed(!bottomSidebarCollapsed);
+  };
+
+  // Companion mapping
+  const companionMapping = {
+    letsgo: {
+      name: "Letsgo",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F5524e36757e049b29b018c866cb3f01e?format=webp&width=800",
+    },
+    rushmore: {
+      name: "Rushmore",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F6b282f7859fa4a96aab4f5d21fe7d27d?format=webp&width=800",
+    },
+    uni: {
+      name: "Uni",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff6c3edc98a444c79ba1188aeab1c17f6?format=webp&width=800",
+    },
+    cody: {
+      name: "Cody",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F067d19c68a9149c6a32a29cf3f5ebb0d?format=webp&width=800",
+    },
+    doma: {
+      name: "Doma",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F12511fbec0c84354b93ec8ca250c92b6?format=webp&width=800",
+    },
+    rooty: {
+      name: "Rooty",
+      image:
+        "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fc2faa21a880b45d9be3c40dddb0cd20f?format=webp&width=800",
+    },
+  };
+
+  const handleCompanionSelect = (companionId: string) => {
+    const companion =
+      companionMapping[companionId as keyof typeof companionMapping];
+    if (companion) {
+      setSelectedCompanion({
+        id: companionId,
+        name: companion.name,
+        image: companion.image,
+      });
+    }
+  };
+
+  // Dynamic bottom menu items based on selected companion
+  const dynamicBottomMenuItems = bottomMenuItems || [
+    {
+      src: selectedCompanion.image,
+      alt: selectedCompanion.name,
+      delay: 100,
+    },
+  ];
+
+  const sidebarStyle = {
+    bgcolor: "#1C2051",
+    border: "1px solid rgba(255, 255, 255, 0.2)",
+    borderLeft: "none",
+    borderRadius: "0 15px 15px 0",
+    boxShadow: "0px 8px 32px rgba(0, 0, 0, 0.4)",
+    transition: "all 0.5s ease-in-out",
+    position: "relative",
+  };
+
+  const menuItemStyle = {
+    width: 48,
+    height: 48,
+    borderRadius: "16px",
+    overflow: "hidden",
+    cursor: "pointer",
+    transition: "all 0.3s ease",
+    bgcolor: "rgba(255, 255, 255, 0.05)",
+    border: "1px solid rgba(255, 255, 255, 0.1)",
+    backdropFilter: "blur(8px)",
+    "&:hover": {
+      transform: "scale(1.1)",
+      boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)",
+      bgcolor: "rgba(255, 255, 255, 0.15)",
+      borderColor: "rgba(255, 255, 255, 0.3)",
+    },
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        left: 0,
+        top: 128,
+        zIndex: 30,
+        display: "flex",
+        flexDirection: "column",
+        width: "auto",
+      }}
+    >
+      {/* Container with zero margin, aligned to left edge */}
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, py: 2, overflow: "hidden" }}>
+        {/* Top Sidebar Section */}
+        <Box sx={{ position: "relative" }}>
+          <Box
+            sx={{
+              ...sidebarStyle,
+              width: topSidebarCollapsed ? 32 : 80,
+              height: "auto",
+              maxHeight: "calc(60vh)",
+            }}
+          >
+            {/* Menu Items */}
+            <Box
+              sx={{
+                transition: "all 0.5s ease-in-out",
+                overflow: "hidden",
+                width: topSidebarCollapsed ? 0 : 64,
+                opacity: topSidebarCollapsed ? 0 : 1,
+                p: 2,
+              }}
+            >
+              <Box sx={{ overflowY: "auto", maxHeight: "calc(60vh - 32px)" }}>
+                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1.5 }}>
+                  {topMenuItems.map((item, index) => (
+                    <Box
+                      key={item.alt}
+                      sx={{
+                        position: "relative",
+                        animation: showTopWaveEffect
+                          ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
+                          : "none",
+                        transform: showTopWaveEffect ? "scale(1)" : "scale(0)",
+                        "@keyframes popIn": {
+                          "0%": {
+                            transform: "scale(0) rotate(0deg)",
+                            opacity: 0,
+                          },
+                          "50%": {
+                            transform: "scale(1.2) rotate(5deg)",
+                          },
+                          "100%": {
+                            transform: "scale(1) rotate(0deg)",
+                            opacity: 1,
+                          },
+                        },
+                        "@keyframes wave": {
+                          "0%, 100%": {
+                            transform: "scale(1) translateY(0px)",
+                          },
+                          "25%": {
+                            transform: "scale(1.05) translateY(-2px)",
+                          },
+                          "50%": {
+                            transform: "scale(1) translateY(0px)",
+                          },
+                          "75%": {
+                            transform: "scale(1.05) translateY(2px)",
+                          },
+                        },
+                      }}
+                    >
+                      <Tooltip
+                        title={item.alt}
+                        placement="right"
+                        arrow
+                        sx={{
+                          "& .MuiTooltip-tooltip": {
+                            bgcolor: "#1C2051",
+                            border: "1px solid rgba(255, 255, 255, 0.2)",
+                            borderRadius: "12px",
+                            color: "white",
+                            fontSize: "12px",
+                            fontWeight: 500,
+                          },
+                          "& .MuiTooltip-arrow": {
+                            color: "#1C2051",
+                          },
+                        }}
+                      >
+                        <Box
+                          sx={menuItemStyle}
+                          onClick={() => {
+                            if (item.alt === "Menu") {
+                              setIsWheelModalOpen(true);
+                            } else {
+                              onMenuItemClick?.(item.alt, index);
+                            }
+                          }}
+                        >
+                          <Box
+                            component="img"
+                            src={item.src}
+                            alt={item.alt}
+                            sx={{
+                              width: "100%",
+                              height: "100%",
+                              objectFit: "cover",
+                              transition: "transform 0.3s ease",
+                              "&:hover": {
+                                transform: "rotate(12deg)",
+                              },
+                            }}
+                          />
+                        </Box>
+                      </Tooltip>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            </Box>
+
+            {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
+            <Box
+              sx={{
+                position: "absolute",
+                right: 2,
+                top: "50%",
+                transform: "translateY(-50%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <IconButton
+                onClick={toggleTopSidebar}
+                sx={{
+                  width: 24,
+                  height: 32,
+                  bgcolor: "transparent",
+                  "&:hover": {
+                    bgcolor: "rgba(255, 255, 255, 0.1)",
+                    transform: "scale(1.1)",
+                  },
+                  borderRadius: "6px",
+                  transition: "all 0.3s ease",
+                  p: 0,
+                }}
+              >
+                <Box
+                  component="img"
+                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F7504875ba38348f8bb8df1ca5aaf3464?format=webp&width=800"
+                  alt="Toggle"
+                  sx={{
+                    width: 16,
+                    height: 16,
+                    objectFit: "contain",
+                    transition: "transform 0.3s ease",
+                    transform: topSidebarCollapsed ? "rotate(0deg)" : "rotate(180deg)",
+                    "&:hover": {
+                      transform: topSidebarCollapsed ? "scale(1.25)" : "rotate(180deg) scale(1.25)",
+                    },
+                  }}
+                />
+              </IconButton>
+            </Box>
+          </Box>
+        </Box>
+
+        {/* Bottom Sidebar Section */}
+        <Box sx={{ position: "relative" }}>
+          <Box
+            sx={{
+              ...sidebarStyle,
+              width: bottomSidebarCollapsed ? 32 : 80,
+              height: "auto",
+              maxHeight: "calc(30vh)",
+            }}
+          >
+            {/* Menu Items */}
+            <Box
+              sx={{
+                transition: "all 0.5s ease-in-out",
+                overflow: "hidden",
+                width: bottomSidebarCollapsed ? 0 : 64,
+                opacity: bottomSidebarCollapsed ? 0 : 1,
+                p: 1.5,
+              }}
+            >
+              <Box sx={{ overflowY: "auto", maxHeight: "calc(30vh - 24px)" }}>
+                <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1 }}>
+                  {dynamicBottomMenuItems.map((item, index) => (
+                    <Box
+                      key={item.alt}
+                      sx={{
+                        position: "relative",
+                        animation: showBottomWaveEffect
+                          ? `popIn 0.6s ease-out ${item.delay}ms both, wave 2s ease-in-out ${item.delay + 600}ms both`
+                          : "none",
+                        transform: showBottomWaveEffect ? "scale(1)" : "scale(0)",
+                      }}
+                    >
+                      <Tooltip
+                        title={item.alt}
+                        placement="right"
+                        arrow
+                        sx={{
+                          "& .MuiTooltip-tooltip": {
+                            bgcolor: "#1C2051",
+                            border: "1px solid rgba(255, 255, 255, 0.2)",
+                            borderRadius: "12px",
+                            color: "white",
+                            fontSize: "12px",
+                            fontWeight: 500,
+                          },
+                          "& .MuiTooltip-arrow": {
+                            color: "#1C2051",
+                          },
+                        }}
+                      >
+                        <Box
+                          sx={menuItemStyle}
+                          onClick={() => {
+                            if (
+                              item.alt === selectedCompanion.name ||
+                              item.alt === "Selected Companion"
+                            ) {
+                              setIsCompanionModalOpen(true);
+                            } else {
+                              onMenuItemClick?.(item.alt, index);
+                            }
+                          }}
+                        >
+                          <Box
+                            component="img"
+                            src={item.src}
+                            alt={item.alt}
+                            sx={{
+                              width: "100%",
+                              height: "100%",
+                              objectFit: "cover",
+                              transition: "transform 0.3s ease",
+                              "&:hover": {
+                                transform: "rotate(12deg)",
+                              },
+                            }}
+                          />
+                        </Box>
+                      </Tooltip>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            </Box>
+
+            {/* Toggle Button - Inside sidebar, right edge, vertically centered */}
+            <Box
+              sx={{
+                position: "absolute",
+                right: 2,
+                top: "50%",
+                transform: "translateY(-50%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <IconButton
+                onClick={toggleBottomSidebar}
+                sx={{
+                  width: 24,
+                  height: 32,
+                  bgcolor: "transparent",
+                  "&:hover": {
+                    bgcolor: "rgba(255, 255, 255, 0.1)",
+                    transform: "scale(1.1)",
+                  },
+                  borderRadius: "6px",
+                  transition: "all 0.3s ease",
+                  p: 0,
+                }}
+              >
+                <Box
+                  component="img"
+                  src="https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F7504875ba38348f8bb8df1ca5aaf3464?format=webp&width=800"
+                  alt="Toggle"
+                  sx={{
+                    width: 16,
+                    height: 16,
+                    objectFit: "contain",
+                    transition: "transform 0.3s ease",
+                    transform: bottomSidebarCollapsed ? "rotate(0deg)" : "rotate(180deg)",
+                    "&:hover": {
+                      transform: bottomSidebarCollapsed ? "scale(1.25)" : "rotate(180deg) scale(1.25)",
+                    },
+                  }}
+                />
+              </IconButton>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* TaleTree Wheel Modal */}
+      <MuiTaleTreeWheelModal
+        isOpen={isWheelModalOpen}
+        onClose={() => setIsWheelModalOpen(false)}
+      />
+
+      {/* Companion Selection Modal */}
+      <MuiCompanionSelectionModal
+        isOpen={isCompanionModalOpen}
+        onClose={() => setIsCompanionModalOpen(false)}
+        onSelectCompanion={(companionId) => {
+          handleCompanionSelect(companionId);
+          console.log("Selected companion:", companionId);
+        }}
+      />
+    </Box>
+  );
+}

--- a/client/components/signup-mui/MuiSignupFooter.jsx
+++ b/client/components/signup-mui/MuiSignupFooter.jsx
@@ -1,0 +1,226 @@
+import { Box, Container, Typography, Grid, Link } from "@mui/material";
+
+const MuiSignupFooter = () => {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        bgcolor: "#312e81",
+        color: "white",
+        py: 6,
+        px: 4,
+      }}
+    >
+      <Container maxWidth="xl">
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            justifyContent: "space-between",
+          }}
+        >
+          <Box sx={{ mb: { xs: 4, md: 0 } }}>
+            <Typography
+              variant="h6"
+              sx={{
+                fontSize: "20px",
+                fontWeight: 700,
+                mb: 2,
+              }}
+            >
+              TaleTree Inc.
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: "#d1d5db",
+                fontSize: "14px",
+              }}
+            >
+              149 Barrow St, Floor 2nd, New York, NY 10014, USA
+            </Typography>
+          </Box>
+
+          <Grid container spacing={4} sx={{ maxWidth: { md: "50%" } }}>
+            <Grid item xs={6} md={4}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 600,
+                  mb: 1.5,
+                  fontSize: "16px",
+                }}
+              >
+                Company
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Our Story
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Careers
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Contact
+                </Link>
+              </Box>
+            </Grid>
+
+            <Grid item xs={6} md={4}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 600,
+                  mb: 1.5,
+                  fontSize: "16px",
+                }}
+              >
+                Support
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Getting Started
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Help Center
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Server Status
+                </Link>
+              </Box>
+            </Grid>
+
+            <Grid item xs={12} md={4}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 600,
+                  mb: 1.5,
+                  fontSize: "16px",
+                }}
+              >
+                Follow us
+              </Typography>
+              <Box sx={{ display: "flex", gap: 1.5 }}>
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+              </Box>
+            </Grid>
+          </Grid>
+        </Box>
+
+        <Box
+          sx={{
+            borderTop: "1px solid #374151",
+            mt: 4,
+            pt: 3,
+            textAlign: "center",
+          }}
+        >
+          <Typography
+            variant="body2"
+            sx={{
+              fontSize: "14px",
+              color: "#9ca3af",
+            }}
+          >
+            2024, TaleTree Inc. All rights reserved. | Email:
+            contact@taletree.com
+          </Typography>
+        </Box>
+      </Container>
+    </Box>
+  );
+};
+
+export default MuiSignupFooter;

--- a/client/components/signup-mui/MuiSignupFooter.tsx
+++ b/client/components/signup-mui/MuiSignupFooter.tsx
@@ -1,0 +1,226 @@
+import { Box, Container, Typography, Grid, Link } from "@mui/material";
+
+const MuiSignupFooter = () => {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        bgcolor: "#312e81",
+        color: "white",
+        py: 6,
+        px: 4,
+      }}
+    >
+      <Container maxWidth="xl">
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            justifyContent: "space-between",
+          }}
+        >
+          <Box sx={{ mb: { xs: 4, md: 0 } }}>
+            <Typography
+              variant="h6"
+              sx={{
+                fontSize: "20px",
+                fontWeight: 700,
+                mb: 2,
+              }}
+            >
+              TaleTree Inc.
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: "#d1d5db",
+                fontSize: "14px",
+              }}
+            >
+              149 Barrow St, Floor 2nd, New York, NY 10014, USA
+            </Typography>
+          </Box>
+
+          <Grid container spacing={4} sx={{ maxWidth: { md: "50%" } }}>
+            <Grid item xs={6} md={4}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 600,
+                  mb: 1.5,
+                  fontSize: "16px",
+                }}
+              >
+                Company
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Our Story
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Careers
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Contact
+                </Link>
+              </Box>
+            </Grid>
+
+            <Grid item xs={6} md={4}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 600,
+                  mb: 1.5,
+                  fontSize: "16px",
+                }}
+              >
+                Support
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Getting Started
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Help Center
+                </Link>
+                <Link
+                  href="#"
+                  sx={{
+                    color: "#d1d5db",
+                    textDecoration: "none",
+                    fontSize: "14px",
+                    "&:hover": {
+                      color: "white",
+                    },
+                  }}
+                >
+                  Server Status
+                </Link>
+              </Box>
+            </Grid>
+
+            <Grid item xs={12} md={4}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 600,
+                  mb: 1.5,
+                  fontSize: "16px",
+                }}
+              >
+                Follow us
+              </Typography>
+              <Box sx={{ display: "flex", gap: 1.5 }}>
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    bgcolor: "#6b7280",
+                    borderRadius: "50%",
+                  }}
+                />
+              </Box>
+            </Grid>
+          </Grid>
+        </Box>
+
+        <Box
+          sx={{
+            borderTop: "1px solid #374151",
+            mt: 4,
+            pt: 3,
+            textAlign: "center",
+          }}
+        >
+          <Typography
+            variant="body2"
+            sx={{
+              fontSize: "14px",
+              color: "#9ca3af",
+            }}
+          >
+            2024, TaleTree Inc. All rights reserved. | Email:
+            contact@taletree.com
+          </Typography>
+        </Box>
+      </Container>
+    </Box>
+  );
+};
+
+export default MuiSignupFooter;

--- a/client/components/signup-mui/MuiTaleTreeWheelModal.jsx
+++ b/client/components/signup-mui/MuiTaleTreeWheelModal.jsx
@@ -2,10 +2,7 @@ import { useState } from "react";
 import { Box, Modal, IconButton, Chip, Typography } from "@mui/material";
 import { Close } from "@mui/icons-material";
 
-export function MuiTaleTreeWheelModal({
-  isOpen,
-  onClose,
-}) {
+export function MuiTaleTreeWheelModal({ isOpen, onClose }) {
   const [hoveredAction, setHoveredAction] = useState(null);
 
   // Calculate circular positions using trigonometry
@@ -115,7 +112,14 @@ export function MuiTaleTreeWheelModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", mb: 3 }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            mb: 3,
+          }}
+        >
           <Chip
             label="The TaleTree Method"
             sx={{
@@ -128,7 +132,15 @@ export function MuiTaleTreeWheelModal({
         </Box>
 
         {/* Wheel Container */}
-        <Box sx={{ flex: 1, position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <Box
+          sx={{
+            flex: 1,
+            position: "relative",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
           {/* Center Close Button */}
           <IconButton
             onClick={onClose}
@@ -166,7 +178,13 @@ export function MuiTaleTreeWheelModal({
               onMouseEnter={() => setHoveredAction(action.id)}
               onMouseLeave={() => setHoveredAction(null)}
             >
-              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                }}
+              >
                 {/* Action Icon */}
                 <Box
                   sx={{
@@ -226,7 +244,8 @@ export function MuiTaleTreeWheelModal({
                   p: 1.5,
                   borderRadius: "8px",
                   maxWidth: "300px",
-                  boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+                  boxShadow:
+                    "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
                   position: "relative",
                 }}
               >

--- a/client/components/signup-mui/MuiTaleTreeWheelModal.jsx
+++ b/client/components/signup-mui/MuiTaleTreeWheelModal.jsx
@@ -1,0 +1,263 @@
+import { useState } from "react";
+import { Box, Modal, IconButton, Chip, Typography } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+export function MuiTaleTreeWheelModal({
+  isOpen,
+  onClose,
+}) {
+  const [hoveredAction, setHoveredAction] = useState(null);
+
+  // Calculate circular positions using trigonometry
+  const radius = 150; // Radius of the circle
+  const centerX = 0; // Center X (will be positioned relative to container center)
+  const centerY = 0; // Center Y (will be positioned relative to container center)
+
+  const wheelActions = [
+    {
+      id: "imagine",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fbe8068e94c034f37b80ff496f9836079?format=webp&width=800",
+      label: "Imagine",
+      color: "#f97316",
+      description:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet vel lectus sed varius.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "play",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F392f37f775f74478ab0ebdf2db3f8b18?format=webp&width=800",
+      label: "Play",
+      color: "#3b82f6",
+      description:
+        "Engage in interactive storytelling and creative play activities.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "create",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F084deab3e0e14195a8bd0e2f6adf11a8?format=webp&width=800",
+      label: "Create",
+      color: "#06b6d4",
+      description: "Build and craft your own stories and creative content.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "store",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff5ca235dac1145ad9e9f34e3ffb685b1?format=webp&width=800",
+      label: "Store",
+      color: "#22c55e",
+      description: "Save and organize your creative works and stories.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "reflect",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F84bf40f92efe4b4ea397148088e0ce03?format=webp&width=800",
+      label: "Reflect",
+      color: "#a855f7",
+      description: "Think about your learning journey and growth.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((5 * Math.PI) / 6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos((5 * Math.PI) / 6)}px)`,
+      },
+    },
+    {
+      id: "reward",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F2728d898d1bb4efabee72f00d281e7cf?format=webp&width=800",
+      label: "Reward",
+      color: "#ec4899",
+      description: "Celebrate achievements and milestones in your journey.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((-5 * Math.PI) / 6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos((-5 * Math.PI) / 6)}px)`,
+      },
+    },
+  ];
+
+  const getHoveredAction = () => {
+    return wheelActions.find((action) => action.id === hoveredAction);
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backdropFilter: "blur(8px)",
+        bgcolor: "rgba(0, 0, 0, 0.4)",
+      }}
+    >
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: "80rem",
+          height: "100%",
+          maxHeight: "90vh",
+          display: "flex",
+          flexDirection: "column",
+          p: 2,
+          position: "relative",
+          outline: "none",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", mb: 3 }}>
+          <Chip
+            label="The TaleTree Method"
+            sx={{
+              bgcolor: "rgba(255, 255, 255, 0.2)",
+              color: "white",
+              backdropFilter: "blur(8px)",
+              fontSize: "12px",
+            }}
+          />
+        </Box>
+
+        {/* Wheel Container */}
+        <Box sx={{ flex: 1, position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+          {/* Center Close Button */}
+          <IconButton
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              width: 64,
+              height: 64,
+              bgcolor: "#ef4444",
+              "&:hover": {
+                bgcolor: "#dc2626",
+              },
+              borderRadius: "50%",
+              zIndex: 20,
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              transition: "background-color 0.2s ease",
+              boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)",
+            }}
+          >
+            <Close sx={{ width: 32, height: 32, color: "white" }} />
+          </IconButton>
+
+          {/* Action Items - Circular Layout */}
+          {wheelActions.map((action) => (
+            <Box
+              key={action.id}
+              sx={{
+                position: "absolute",
+                cursor: "pointer",
+                top: action.position.top,
+                left: action.position.left,
+                transform: "translate(-50%, -50%)",
+              }}
+              onMouseEnter={() => setHoveredAction(action.id)}
+              onMouseLeave={() => setHoveredAction(null)}
+            >
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                {/* Action Icon */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    transition: "transform 0.2s ease",
+                    "&:hover": {
+                      transform: "scale(1.1)",
+                    },
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={action.icon}
+                    alt={action.label}
+                    sx={{
+                      width: 64,
+                      height: 64,
+                      objectFit: "contain",
+                    }}
+                  />
+                </Box>
+                {/* Label */}
+                <Chip
+                  label={action.label}
+                  sx={{
+                    bgcolor: action.color,
+                    color: "white",
+                    fontSize: "14px",
+                    fontWeight: 500,
+                    mt: 1,
+                  }}
+                />
+              </Box>
+            </Box>
+          ))}
+
+          {/* Hover Description */}
+          {hoveredAction && (
+            <Box
+              sx={{
+                position: "absolute",
+                zIndex: 30,
+                transition: "opacity 0.15s ease-in-out",
+                opacity: 1,
+                top: `calc(${getHoveredAction()?.position.top} - 80px)`,
+                left: getHoveredAction()?.position.left,
+                transform: "translate(-50%, 0)",
+                pointerEvents: "none",
+              }}
+            >
+              <Box
+                sx={{
+                  bgcolor: getHoveredAction()?.color,
+                  color: "white",
+                  p: 1.5,
+                  borderRadius: "8px",
+                  maxWidth: "300px",
+                  boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+                  position: "relative",
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "12px",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {getHoveredAction()?.description}
+                </Typography>
+                {/* Tooltip arrow */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: "100%",
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    width: 0,
+                    height: 0,
+                    borderLeft: "12px solid transparent",
+                    borderRight: "12px solid transparent",
+                    borderTop: `12px solid ${getHoveredAction()?.color}`,
+                  }}
+                />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/client/components/signup-mui/MuiTaleTreeWheelModal.tsx
+++ b/client/components/signup-mui/MuiTaleTreeWheelModal.tsx
@@ -1,0 +1,277 @@
+import { useState } from "react";
+import { Box, Modal, IconButton, Chip, Typography } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+interface WheelAction {
+  id: string;
+  icon: string;
+  label: string;
+  color: string;
+  description: string;
+  position: { top: string; left: string };
+}
+
+interface MuiTaleTreeWheelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function MuiTaleTreeWheelModal({
+  isOpen,
+  onClose,
+}: MuiTaleTreeWheelModalProps) {
+  const [hoveredAction, setHoveredAction] = useState<string | null>(null);
+
+  // Calculate circular positions using trigonometry
+  const radius = 150; // Radius of the circle
+  const centerX = 0; // Center X (will be positioned relative to container center)
+  const centerY = 0; // Center Y (will be positioned relative to container center)
+
+  const wheelActions: WheelAction[] = [
+    {
+      id: "imagine",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Fbe8068e94c034f37b80ff496f9836079?format=webp&width=800",
+      label: "Imagine",
+      color: "#f97316",
+      description:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet vel lectus sed varius.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 2)}px)`, // -90° (top)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "play",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F392f37f775f74478ab0ebdf2db3f8b18?format=webp&width=800",
+      label: "Play",
+      color: "#3b82f6",
+      description:
+        "Engage in interactive storytelling and creative play activities.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(-Math.PI / 6)}px)`, // -30° (top right)
+        left: `calc(50% + ${centerX + radius * Math.cos(-Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "create",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F084deab3e0e14195a8bd0e2f6adf11a8?format=webp&width=800",
+      label: "Create",
+      color: "#06b6d4",
+      description: "Build and craft your own stories and creative content.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 6)}px)`, // 30° (bottom right)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 6)}px)`,
+      },
+    },
+    {
+      id: "store",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2Ff5ca235dac1145ad9e9f34e3ffb685b1?format=webp&width=800",
+      label: "Store",
+      color: "#22c55e",
+      description: "Save and organize your creative works and stories.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin(Math.PI / 2)}px)`, // 90° (bottom)
+        left: `calc(50% + ${centerX + radius * Math.cos(Math.PI / 2)}px)`,
+      },
+    },
+    {
+      id: "reflect",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F84bf40f92efe4b4ea397148088e0ce03?format=webp&width=800",
+      label: "Reflect",
+      color: "#a855f7",
+      description: "Think about your learning journey and growth.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((5 * Math.PI) / 6)}px)`, // 150° (bottom left)
+        left: `calc(50% + ${centerX + radius * Math.cos((5 * Math.PI) / 6)}px)`,
+      },
+    },
+    {
+      id: "reward",
+      icon: "https://cdn.builder.io/api/v1/image/assets%2F0b5ad4e8e5f84db5a19db37317c1643d%2F2728d898d1bb4efabee72f00d281e7cf?format=webp&width=800",
+      label: "Reward",
+      color: "#ec4899",
+      description: "Celebrate achievements and milestones in your journey.",
+      position: {
+        top: `calc(50% + ${centerY + radius * Math.sin((-5 * Math.PI) / 6)}px)`, // -150° (top left)
+        left: `calc(50% + ${centerX + radius * Math.cos((-5 * Math.PI) / 6)}px)`,
+      },
+    },
+  ];
+
+  const getHoveredAction = () => {
+    return wheelActions.find((action) => action.id === hoveredAction);
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backdropFilter: "blur(8px)",
+        bgcolor: "rgba(0, 0, 0, 0.4)",
+      }}
+    >
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: "80rem",
+          height: "100%",
+          maxHeight: "90vh",
+          display: "flex",
+          flexDirection: "column",
+          p: 2,
+          position: "relative",
+          outline: "none",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", mb: 3 }}>
+          <Chip
+            label="The TaleTree Method"
+            sx={{
+              bgcolor: "rgba(255, 255, 255, 0.2)",
+              color: "white",
+              backdropFilter: "blur(8px)",
+              fontSize: "12px",
+            }}
+          />
+        </Box>
+
+        {/* Wheel Container */}
+        <Box sx={{ flex: 1, position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+          {/* Center Close Button */}
+          <IconButton
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              width: 64,
+              height: 64,
+              bgcolor: "#ef4444",
+              "&:hover": {
+                bgcolor: "#dc2626",
+              },
+              borderRadius: "50%",
+              zIndex: 20,
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              transition: "background-color 0.2s ease",
+              boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)",
+            }}
+          >
+            <Close sx={{ width: 32, height: 32, color: "white" }} />
+          </IconButton>
+
+          {/* Action Items - Circular Layout */}
+          {wheelActions.map((action) => (
+            <Box
+              key={action.id}
+              sx={{
+                position: "absolute",
+                cursor: "pointer",
+                top: action.position.top,
+                left: action.position.left,
+                transform: "translate(-50%, -50%)",
+              }}
+              onMouseEnter={() => setHoveredAction(action.id)}
+              onMouseLeave={() => setHoveredAction(null)}
+            >
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+                {/* Action Icon */}
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    transition: "transform 0.2s ease",
+                    "&:hover": {
+                      transform: "scale(1.1)",
+                    },
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={action.icon}
+                    alt={action.label}
+                    sx={{
+                      width: 64,
+                      height: 64,
+                      objectFit: "contain",
+                    }}
+                  />
+                </Box>
+                {/* Label */}
+                <Chip
+                  label={action.label}
+                  sx={{
+                    bgcolor: action.color,
+                    color: "white",
+                    fontSize: "14px",
+                    fontWeight: 500,
+                    mt: 1,
+                  }}
+                />
+              </Box>
+            </Box>
+          ))}
+
+          {/* Hover Description */}
+          {hoveredAction && (
+            <Box
+              sx={{
+                position: "absolute",
+                zIndex: 30,
+                transition: "opacity 0.15s ease-in-out",
+                opacity: 1,
+                top: `calc(${getHoveredAction()?.position.top} - 80px)`,
+                left: getHoveredAction()?.position.left,
+                transform: "translate(-50%, 0)",
+                pointerEvents: "none",
+              }}
+            >
+              <Box
+                sx={{
+                  bgcolor: getHoveredAction()?.color,
+                  color: "white",
+                  p: 1.5,
+                  borderRadius: "8px",
+                  maxWidth: "300px",
+                  boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+                  position: "relative",
+                }}
+              >
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: "12px",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {getHoveredAction()?.description}
+                </Typography>
+                {/* Tooltip arrow */}
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: "100%",
+                    left: "50%",
+                    transform: "translateX(-50%)",
+                    width: 0,
+                    height: 0,
+                    borderLeft: "12px solid transparent",
+                    borderRight: "12px solid transparent",
+                    borderTop: `12px solid ${getHoveredAction()?.color}`,
+                  }}
+                />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/client/pages/Signup.tsx
+++ b/client/pages/Signup.tsx
@@ -10,6 +10,7 @@ import EducatorsSection from "@/components/signup/EducatorsSection";
 import ExpertsSection from "@/components/signup/ExpertsSection";
 import SignupFooter from "@/components/signup/SignupFooter";
 import Plans from "./Plans";
+import "../styles/signup.css";
 
 const Signup = () => {
   const [showPlans, setShowPlans] = useState(false);
@@ -18,9 +19,9 @@ const Signup = () => {
     return <Plans />;
   }
   return (
-    <div className="relative">
+    <div className="signup-page">
       {/* Hero Section - Full Viewport */}
-      <div className="relative z-0">
+      <div className="signup-hero-container">
         {/* Stars/Decorative Elements */}
         <DecorativeStars />
 
@@ -29,7 +30,7 @@ const Signup = () => {
       </div>
 
       {/* Content Sections - Below Hero */}
-      <div className="relative z-10 bg-white">
+      <div className="signup-content-container">
         {/* Plans Strip - Inside content sections at top */}
         <PlansStrip onShowPlans={() => setShowPlans(true)} />
         <CreativitySection />
@@ -41,7 +42,7 @@ const Signup = () => {
       </div>
 
       {/* Footer */}
-      <div className="relative z-10">
+      <div className="signup-footer-container">
         <SignupFooter />
       </div>
     </div>

--- a/client/pages/SignupMui.jsx
+++ b/client/pages/SignupMui.jsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { Box, Container } from "@mui/material";
+import MuiDecorativeStars from "@/components/signup-mui/MuiDecorativeStars";
+import MuiHeroSection from "@/components/signup-mui/MuiHeroSection";
+import MuiPlansStrip from "@/components/signup-mui/MuiPlansStrip";
+import MuiCreativitySection from "@/components/signup-mui/MuiCreativitySection";
+import MuiIntroducingSection from "@/components/signup-mui/MuiIntroducingSection";
+import MuiLatestNewsSection from "@/components/signup-mui/MuiLatestNewsSection";
+import MuiParentsSection from "@/components/signup-mui/MuiParentsSection";
+import MuiEducatorsSection from "@/components/signup-mui/MuiEducatorsSection";
+import MuiExpertsSection from "@/components/signup-mui/MuiExpertsSection";
+import MuiSignupFooter from "@/components/signup-mui/MuiSignupFooter";
+import Plans from "./Plans";
+import "../styles/signup-mui.css";
+
+const SignupMui = () => {
+  const [showPlans, setShowPlans] = useState(false);
+
+  if (showPlans) {
+    return <Plans />;
+  }
+
+  return (
+    <div className="signup-mui-page">
+      {/* Hero Section - Full Viewport */}
+      <div className="signup-hero-wrapper">
+        {/* Stars/Decorative Elements */}
+        <MuiDecorativeStars />
+
+        {/* Main Hero Section */}
+        <MuiHeroSection />
+      </div>
+
+      {/* Content Sections - Below Hero */}
+      <div className="signup-content-wrapper">
+        {/* Plans Strip - Inside content sections at top */}
+        <MuiPlansStrip onShowPlans={() => setShowPlans(true)} />
+        <MuiCreativitySection />
+        <MuiIntroducingSection />
+        <MuiLatestNewsSection />
+        <MuiParentsSection />
+        <MuiEducatorsSection />
+        <MuiExpertsSection />
+      </div>
+
+      {/* Footer */}
+      <div className="signup-footer-wrapper">
+        <MuiSignupFooter />
+      </div>
+    </div>
+  );
+};
+
+export default SignupMui;

--- a/client/pages/SignupMui.jsx
+++ b/client/pages/SignupMui.jsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
 import { Box, Container } from "@mui/material";
-import MuiDecorativeStars from "@/components/signup-mui/MuiDecorativeStars";
-import MuiHeroSection from "@/components/signup-mui/MuiHeroSection";
-import MuiPlansStrip from "@/components/signup-mui/MuiPlansStrip";
-import MuiCreativitySection from "@/components/signup-mui/MuiCreativitySection";
-import MuiIntroducingSection from "@/components/signup-mui/MuiIntroducingSection";
-import MuiLatestNewsSection from "@/components/signup-mui/MuiLatestNewsSection";
-import MuiParentsSection from "@/components/signup-mui/MuiParentsSection";
-import MuiEducatorsSection from "@/components/signup-mui/MuiEducatorsSection";
-import MuiExpertsSection from "@/components/signup-mui/MuiExpertsSection";
-import MuiSignupFooter from "@/components/signup-mui/MuiSignupFooter";
+import MuiDecorativeStars from "@/components/signup-mui/MuiDecorativeStars.jsx";
+import MuiHeroSection from "@/components/signup-mui/MuiHeroSection.jsx";
+import MuiPlansStrip from "@/components/signup-mui/MuiPlansStrip.jsx";
+import MuiCreativitySection from "@/components/signup-mui/MuiCreativitySection.jsx";
+import MuiIntroducingSection from "@/components/signup-mui/MuiIntroducingSection.jsx";
+import MuiLatestNewsSection from "@/components/signup-mui/MuiLatestNewsSection.jsx";
+import MuiParentsSection from "@/components/signup-mui/MuiParentsSection.jsx";
+import MuiEducatorsSection from "@/components/signup-mui/MuiEducatorsSection.jsx";
+import MuiExpertsSection from "@/components/signup-mui/MuiExpertsSection.jsx";
+import MuiSignupFooter from "@/components/signup-mui/MuiSignupFooter.jsx";
 import Plans from "./Plans";
 import "../styles/signup-mui.css";
 

--- a/client/pages/SignupMui.tsx
+++ b/client/pages/SignupMui.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { Box, Container } from "@mui/material";
+import MuiDecorativeStars from "@/components/signup-mui/MuiDecorativeStars";
+import MuiHeroSection from "@/components/signup-mui/MuiHeroSection";
+import MuiPlansStrip from "@/components/signup-mui/MuiPlansStrip";
+import MuiCreativitySection from "@/components/signup-mui/MuiCreativitySection";
+import MuiIntroducingSection from "@/components/signup-mui/MuiIntroducingSection";
+import MuiLatestNewsSection from "@/components/signup-mui/MuiLatestNewsSection";
+import MuiParentsSection from "@/components/signup-mui/MuiParentsSection";
+import MuiEducatorsSection from "@/components/signup-mui/MuiEducatorsSection";
+import MuiExpertsSection from "@/components/signup-mui/MuiExpertsSection";
+import MuiSignupFooter from "@/components/signup-mui/MuiSignupFooter";
+import Plans from "./Plans";
+
+const SignupMui = () => {
+  const [showPlans, setShowPlans] = useState(false);
+
+  if (showPlans) {
+    return <Plans />;
+  }
+
+  return (
+    <Box sx={{ position: "relative" }}>
+      {/* Hero Section - Full Viewport */}
+      <Box sx={{ position: "relative", zIndex: 0 }}>
+        {/* Stars/Decorative Elements */}
+        <MuiDecorativeStars />
+
+        {/* Main Hero Section */}
+        <MuiHeroSection />
+      </Box>
+
+      {/* Content Sections - Below Hero */}
+      <Box sx={{ position: "relative", zIndex: 10, bgcolor: "white" }}>
+        {/* Plans Strip - Inside content sections at top */}
+        <MuiPlansStrip onShowPlans={() => setShowPlans(true)} />
+        <MuiCreativitySection />
+        <MuiIntroducingSection />
+        <MuiLatestNewsSection />
+        <MuiParentsSection />
+        <MuiEducatorsSection />
+        <MuiExpertsSection />
+      </Box>
+
+      {/* Footer */}
+      <Box sx={{ position: "relative", zIndex: 10 }}>
+        <MuiSignupFooter />
+      </Box>
+    </Box>
+  );
+};
+
+export default SignupMui;

--- a/client/pages/SignupMui.tsx
+++ b/client/pages/SignupMui.tsx
@@ -11,6 +11,7 @@ import MuiEducatorsSection from "@/components/signup-mui/MuiEducatorsSection";
 import MuiExpertsSection from "@/components/signup-mui/MuiExpertsSection";
 import MuiSignupFooter from "@/components/signup-mui/MuiSignupFooter";
 import Plans from "./Plans";
+import "../styles/signup-mui.css";
 
 const SignupMui = () => {
   const [showPlans, setShowPlans] = useState(false);
@@ -20,18 +21,18 @@ const SignupMui = () => {
   }
 
   return (
-    <Box sx={{ position: "relative" }}>
+    <div className="signup-mui-page">
       {/* Hero Section - Full Viewport */}
-      <Box sx={{ position: "relative", zIndex: 0 }}>
+      <div className="signup-hero-wrapper">
         {/* Stars/Decorative Elements */}
         <MuiDecorativeStars />
 
         {/* Main Hero Section */}
         <MuiHeroSection />
-      </Box>
+      </div>
 
       {/* Content Sections - Below Hero */}
-      <Box sx={{ position: "relative", zIndex: 10, bgcolor: "white" }}>
+      <div className="signup-content-wrapper">
         {/* Plans Strip - Inside content sections at top */}
         <MuiPlansStrip onShowPlans={() => setShowPlans(true)} />
         <MuiCreativitySection />
@@ -40,13 +41,13 @@ const SignupMui = () => {
         <MuiParentsSection />
         <MuiEducatorsSection />
         <MuiExpertsSection />
-      </Box>
+      </div>
 
       {/* Footer */}
-      <Box sx={{ position: "relative", zIndex: 10 }}>
+      <div className="signup-footer-wrapper">
         <MuiSignupFooter />
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 };
 

--- a/client/styles/signup-mui.css
+++ b/client/styles/signup-mui.css
@@ -44,7 +44,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-image: url('https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1920&h=1080&fit=crop&crop=center');
+  background-image: url("https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1920&h=1080&fit=crop&crop=center");
   background-size: cover;
   background-position: center;
   opacity: 0.4;
@@ -56,7 +56,11 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(135deg, rgba(102, 126, 234, 0.8), rgba(118, 75, 162, 0.8));
+  background: linear-gradient(
+    135deg,
+    rgba(102, 126, 234, 0.8),
+    rgba(118, 75, 162, 0.8)
+  );
 }
 
 .hero-content {
@@ -168,7 +172,7 @@
 }
 
 .speech-bubble::before {
-  content: '';
+  content: "";
   position: absolute;
   left: -10px;
   top: 50%;
@@ -314,8 +318,15 @@
 }
 
 @keyframes twinkle {
-  0%, 100% { opacity: 0.3; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.2); }
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.2);
+  }
 }
 
 /* ===== CONTENT SECTIONS STYLES ===== */
@@ -356,7 +367,9 @@
   border-radius: 16px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .content-card:hover {
@@ -421,7 +434,9 @@
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   overflow: hidden;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .news-card:hover {
@@ -692,67 +707,67 @@
   .hero-logo {
     font-size: 32px;
   }
-  
+
   .hero-title {
     font-size: 24px;
   }
-  
+
   .chat-container {
     max-width: 90%;
   }
-  
+
   .companion-container {
     left: 10%;
     width: 80px;
     height: 80px;
   }
-  
+
   .speech-bubble {
     right: 20%;
     max-width: 150px;
     padding: 12px 16px;
   }
-  
+
   .dual-sidebar {
     width: 60px;
     padding: 16px 0;
   }
-  
+
   .sidebar-icon {
     width: 40px;
     height: 40px;
   }
-  
+
   .content-section {
     padding: 32px 16px;
   }
-  
+
   .grid-2-col,
   .grid-3-col {
     grid-template-columns: 1fr;
   }
-  
+
   .grid-news-layout {
     grid-template-columns: 1fr;
   }
-  
+
   .parents-grid {
     grid-template-columns: 1fr;
   }
-  
+
   .introducing-grid {
     grid-template-columns: 1fr;
   }
-  
+
   .fox-illustration-card {
     height: 300px;
   }
-  
+
   .fox-character {
     width: 100px;
     height: 120px;
   }
-  
+
   .fox-body {
     width: 80px;
     height: 80px;
@@ -763,30 +778,30 @@
   .hero-title {
     font-size: 20px;
   }
-  
+
   .chat-input-container {
     width: 98%;
     padding: 0 4px;
   }
-  
+
   .content-section {
     padding: 24px 12px;
   }
-  
+
   .section-header {
     margin-bottom: 24px;
   }
-  
+
   .card-content {
     padding: 16px;
   }
-  
+
   .news-image {
     width: 60px;
     height: 60px;
     margin: 12px;
   }
-  
+
   .news-content {
     padding: 12px 12px 12px 0;
   }
@@ -798,49 +813,123 @@
   text-align: center;
 }
 
-.mb-0 { margin-bottom: 0; }
-.mb-1 { margin-bottom: 8px; }
-.mb-2 { margin-bottom: 16px; }
-.mb-3 { margin-bottom: 24px; }
-.mb-4 { margin-bottom: 32px; }
+.mb-0 {
+  margin-bottom: 0;
+}
+.mb-1 {
+  margin-bottom: 8px;
+}
+.mb-2 {
+  margin-bottom: 16px;
+}
+.mb-3 {
+  margin-bottom: 24px;
+}
+.mb-4 {
+  margin-bottom: 32px;
+}
 
-.p-0 { padding: 0; }
-.p-1 { padding: 8px; }
-.p-2 { padding: 16px; }
-.p-3 { padding: 24px; }
-.p-4 { padding: 32px; }
+.p-0 {
+  padding: 0;
+}
+.p-1 {
+  padding: 8px;
+}
+.p-2 {
+  padding: 16px;
+}
+.p-3 {
+  padding: 24px;
+}
+.p-4 {
+  padding: 32px;
+}
 
-.w-full { width: 100%; }
-.h-full { height: 100%; }
+.w-full {
+  width: 100%;
+}
+.h-full {
+  height: 100%;
+}
 
-.flex { display: flex; }
-.flex-col { flex-direction: column; }
-.items-center { align-items: center; }
-.justify-center { justify-content: center; }
-.justify-between { justify-content: space-between; }
+.flex {
+  display: flex;
+}
+.flex-col {
+  flex-direction: column;
+}
+.items-center {
+  align-items: center;
+}
+.justify-center {
+  justify-content: center;
+}
+.justify-between {
+  justify-content: space-between;
+}
 
-.relative { position: relative; }
-.absolute { position: absolute; }
-.fixed { position: fixed; }
+.relative {
+  position: relative;
+}
+.absolute {
+  position: absolute;
+}
+.fixed {
+  position: fixed;
+}
 
-.z-0 { z-index: 0; }
-.z-1 { z-index: 1; }
-.z-5 { z-index: 5; }
-.z-10 { z-index: 10; }
+.z-0 {
+  z-index: 0;
+}
+.z-1 {
+  z-index: 1;
+}
+.z-5 {
+  z-index: 5;
+}
+.z-10 {
+  z-index: 10;
+}
 
-.bg-white { background-color: white; }
-.bg-transparent { background-color: transparent; }
+.bg-white {
+  background-color: white;
+}
+.bg-transparent {
+  background-color: transparent;
+}
 
-.rounded { border-radius: 8px; }
-.rounded-lg { border-radius: 12px; }
-.rounded-xl { border-radius: 16px; }
-.rounded-2xl { border-radius: 24px; }
-.rounded-full { border-radius: 50%; }
+.rounded {
+  border-radius: 8px;
+}
+.rounded-lg {
+  border-radius: 12px;
+}
+.rounded-xl {
+  border-radius: 16px;
+}
+.rounded-2xl {
+  border-radius: 24px;
+}
+.rounded-full {
+  border-radius: 50%;
+}
 
-.shadow-sm { box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); }
-.shadow { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); }
-.shadow-lg { box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15); }
-.shadow-xl { box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2); }
+.shadow-sm {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+.shadow {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+.shadow-lg {
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+}
+.shadow-xl {
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2);
+}
 
-.transition { transition: all 0.2s ease; }
-.hover-lift:hover { transform: translateY(-2px); }
+.transition {
+  transition: all 0.2s ease;
+}
+.hover-lift:hover {
+  transform: translateY(-2px);
+}

--- a/client/styles/signup-mui.css
+++ b/client/styles/signup-mui.css
@@ -1,0 +1,846 @@
+/* ===== SIGNUP MUI PAGE STYLES ===== */
+
+/* Base Layout */
+.signup-mui-page {
+  position: relative;
+}
+
+.signup-hero-wrapper {
+  position: relative;
+  z-index: 0;
+}
+
+.signup-content-wrapper {
+  position: relative;
+  z-index: 10;
+  background-color: white;
+}
+
+.signup-footer-wrapper {
+  position: relative;
+  z-index: 10;
+}
+
+/* ===== HERO SECTION STYLES ===== */
+
+.hero-section {
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.hero-background-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url('https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1920&h=1080&fit=crop&crop=center');
+  background-size: cover;
+  background-position: center;
+  opacity: 0.4;
+}
+
+.hero-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.8), rgba(118, 75, 162, 0.8));
+}
+
+.hero-content {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 32px 16px;
+}
+
+.hero-logo {
+  font-size: 48px;
+  font-weight: 800;
+  color: white;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.hero-title {
+  font-size: 36px;
+  font-weight: 700;
+  color: white;
+  margin-bottom: 32px;
+  text-align: center;
+  line-height: 1.2;
+}
+
+/* ===== CHAT CONTAINER STYLES ===== */
+
+.chat-container {
+  background-color: white;
+  border-radius: 24px;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  width: 100%;
+  max-width: 500px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.chat-header {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  padding: 20px;
+  text-align: center;
+}
+
+.chat-messages {
+  padding: 24px;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.chat-message {
+  padding: 12px 16px;
+  border-radius: 18px;
+  max-width: 80%;
+  word-wrap: break-word;
+}
+
+.chat-message-bot {
+  background-color: #f3f4f6;
+  color: #374151;
+  align-self: flex-start;
+}
+
+.chat-message-user {
+  background-color: #667eea;
+  color: white;
+  align-self: flex-end;
+}
+
+/* ===== COMPANION STYLES ===== */
+
+.companion-container {
+  position: absolute;
+  left: 15%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100px;
+  height: 100px;
+  z-index: 6;
+}
+
+.companion-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 4px solid white;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+}
+
+.speech-bubble {
+  position: absolute;
+  right: 25%;
+  top: 40%;
+  transform: translateY(-50%);
+  background-color: white;
+  border-radius: 20px;
+  padding: 16px 20px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  max-width: 200px;
+  z-index: 6;
+}
+
+.speech-bubble::before {
+  content: '';
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-right: 10px solid white;
+}
+
+.speech-bubble-text {
+  font-size: 14px;
+  color: #374151;
+  margin: 0;
+}
+
+/* ===== CHAT INPUT STYLES ===== */
+
+.chat-input-container {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 95%;
+  max-width: none;
+  margin: 0 auto;
+  padding: 0 8px;
+  z-index: 7;
+}
+
+.chat-input-wrapper {
+  background-color: white;
+  border-radius: 50px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.chat-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  padding: 12px 0;
+  background: transparent;
+}
+
+.chat-input::placeholder {
+  color: #9ca3af;
+}
+
+.chat-input-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background-color: #667eea;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.chat-input-button:hover {
+  background-color: #5a67d8;
+}
+
+/* ===== SIDEBAR STYLES ===== */
+
+.dual-sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 80px;
+  background-color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  z-index: 8;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 0;
+  gap: 16px;
+}
+
+.sidebar-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background-color: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.sidebar-icon:hover {
+  background-color: #667eea;
+  color: white;
+  transform: translateY(-2px);
+}
+
+/* ===== DECORATIVE STARS ===== */
+
+.decorative-stars {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.star {
+  position: absolute;
+  background-color: white;
+  border-radius: 50%;
+  opacity: 0.7;
+  animation: twinkle 3s infinite ease-in-out;
+}
+
+.star-small {
+  width: 2px;
+  height: 2px;
+}
+
+.star-medium {
+  width: 4px;
+  height: 4px;
+}
+
+.star-large {
+  width: 6px;
+  height: 6px;
+}
+
+@keyframes twinkle {
+  0%, 100% { opacity: 0.3; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+/* ===== CONTENT SECTIONS STYLES ===== */
+
+.content-section {
+  padding: 48px 32px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 32px;
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.section-view-all {
+  color: #9333ea;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.section-view-all:hover {
+  color: #7c3aed;
+}
+
+/* ===== CARD STYLES ===== */
+
+.content-card {
+  background-color: white;
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.content-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+}
+
+.card-image {
+  width: 100%;
+  height: 200px;
+  background-size: cover;
+  background-position: center;
+}
+
+.card-content {
+  padding: 24px;
+}
+
+.card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.card-date {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+/* ===== GRID LAYOUTS ===== */
+
+.grid-container {
+  display: grid;
+  gap: 32px;
+}
+
+.grid-2-col {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.grid-3-col {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.grid-news-layout {
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+}
+
+.news-column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.news-card {
+  display: flex;
+  align-items: center;
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.news-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.news-image {
+  width: 80px;
+  height: 80px;
+  flex-shrink: 0;
+  background-size: cover;
+  background-position: center;
+  margin: 16px;
+  border-radius: 8px;
+}
+
+.news-content {
+  flex: 1;
+  padding: 16px 16px 16px 0;
+}
+
+.news-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 4px;
+  line-height: 1.3;
+}
+
+.news-date {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+/* ===== PARENTS SECTION SPECIFIC ===== */
+
+.parents-grid {
+  display: grid;
+  grid-template-columns: 5fr 3.5fr 3.5fr;
+  gap: 24px;
+}
+
+.parents-card-avatars {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  gap: 8px;
+}
+
+.avatar-circle {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.avatar-inner {
+  width: 20px;
+  height: 20px;
+  background-color: white;
+  border-radius: 50%;
+}
+
+.avatar-purple {
+  background-color: #a855f7;
+}
+
+.avatar-orange {
+  background-color: #f97316;
+}
+
+.avatar-blue {
+  background-color: #3b82f6;
+}
+
+.avatar-green {
+  background-color: #22c55e;
+}
+
+/* ===== INTRODUCING SECTION SPECIFIC ===== */
+
+.introducing-grid {
+  display: grid;
+  grid-template-columns: 8fr 4fr;
+  gap: 32px;
+  margin-bottom: 48px;
+}
+
+.fox-illustration-card {
+  height: 400px;
+  background: linear-gradient(135deg, #1e1b4b 0%, #312e81 30%, #4c1d95 100%);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.fox-character {
+  width: 140px;
+  height: 160px;
+  position: relative;
+  z-index: 3;
+  margin-top: -16px;
+}
+
+.fox-body {
+  width: 110px;
+  height: 110px;
+  background-color: #f87171;
+  border-radius: 50% 50% 45% 45%;
+  position: relative;
+  margin: 0 auto;
+}
+
+.fox-ear {
+  position: absolute;
+  top: -20px;
+  width: 22px;
+  height: 35px;
+  background-color: #f87171;
+  border-radius: 50% 50% 20% 20%;
+}
+
+.fox-ear-left {
+  left: 20px;
+  transform: rotate(-15deg);
+}
+
+.fox-ear-right {
+  right: 20px;
+  transform: rotate(15deg);
+}
+
+.fox-face {
+  position: absolute;
+  top: 25px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 70px;
+  height: 55px;
+  background-color: white;
+  border-radius: 50%;
+}
+
+.fox-eye {
+  position: absolute;
+  top: 15px;
+  width: 12px;
+  height: 8px;
+  background-color: #000;
+  border-radius: 50% 50% 0 0;
+}
+
+.fox-eye-left {
+  left: 16px;
+  transform: rotate(15deg);
+}
+
+.fox-eye-right {
+  right: 16px;
+  transform: rotate(-15deg);
+}
+
+.fox-nose {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 8px;
+  height: 6px;
+  background-color: #000;
+  border-radius: 50%;
+}
+
+.fox-smile {
+  position: absolute;
+  top: 38px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 20px;
+  height: 10px;
+  border: 2px solid #000;
+  border-top: none;
+  border-radius: 0 0 20px 20px;
+}
+
+/* ===== EDUCATORS METHOD DIAGRAM ===== */
+
+.method-diagram {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4c1d95 100%);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.method-circle {
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, #f59e0b, #22c55e, #3b82f6, #ef4444);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.method-inner-circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background-color: #1e1b4b;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.method-tree {
+  width: 40px;
+  height: 60px;
+  position: relative;
+}
+
+.method-tree-trunk {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 8px;
+  height: 20px;
+  background-color: #a855f7;
+  border-radius: 2px;
+}
+
+.method-tree-crown {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 32px;
+  height: 32px;
+  background-color: #22c55e;
+  border-radius: 50%;
+}
+
+.method-label {
+  position: absolute;
+  color: white;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 10px;
+  font-weight: 600;
+  text-align: center;
+  min-width: 60px;
+}
+
+/* ===== RESPONSIVE DESIGN ===== */
+
+@media (max-width: 768px) {
+  .hero-logo {
+    font-size: 32px;
+  }
+  
+  .hero-title {
+    font-size: 24px;
+  }
+  
+  .chat-container {
+    max-width: 90%;
+  }
+  
+  .companion-container {
+    left: 10%;
+    width: 80px;
+    height: 80px;
+  }
+  
+  .speech-bubble {
+    right: 20%;
+    max-width: 150px;
+    padding: 12px 16px;
+  }
+  
+  .dual-sidebar {
+    width: 60px;
+    padding: 16px 0;
+  }
+  
+  .sidebar-icon {
+    width: 40px;
+    height: 40px;
+  }
+  
+  .content-section {
+    padding: 32px 16px;
+  }
+  
+  .grid-2-col,
+  .grid-3-col {
+    grid-template-columns: 1fr;
+  }
+  
+  .grid-news-layout {
+    grid-template-columns: 1fr;
+  }
+  
+  .parents-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .introducing-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .fox-illustration-card {
+    height: 300px;
+  }
+  
+  .fox-character {
+    width: 100px;
+    height: 120px;
+  }
+  
+  .fox-body {
+    width: 80px;
+    height: 80px;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-title {
+    font-size: 20px;
+  }
+  
+  .chat-input-container {
+    width: 98%;
+    padding: 0 4px;
+  }
+  
+  .content-section {
+    padding: 24px 12px;
+  }
+  
+  .section-header {
+    margin-bottom: 24px;
+  }
+  
+  .card-content {
+    padding: 16px;
+  }
+  
+  .news-image {
+    width: 60px;
+    height: 60px;
+    margin: 12px;
+  }
+  
+  .news-content {
+    padding: 12px 12px 12px 0;
+  }
+}
+
+/* ===== UTILITY CLASSES ===== */
+
+.text-center {
+  text-align: center;
+}
+
+.mb-0 { margin-bottom: 0; }
+.mb-1 { margin-bottom: 8px; }
+.mb-2 { margin-bottom: 16px; }
+.mb-3 { margin-bottom: 24px; }
+.mb-4 { margin-bottom: 32px; }
+
+.p-0 { padding: 0; }
+.p-1 { padding: 8px; }
+.p-2 { padding: 16px; }
+.p-3 { padding: 24px; }
+.p-4 { padding: 32px; }
+
+.w-full { width: 100%; }
+.h-full { height: 100%; }
+
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+.items-center { align-items: center; }
+.justify-center { justify-content: center; }
+.justify-between { justify-content: space-between; }
+
+.relative { position: relative; }
+.absolute { position: absolute; }
+.fixed { position: fixed; }
+
+.z-0 { z-index: 0; }
+.z-1 { z-index: 1; }
+.z-5 { z-index: 5; }
+.z-10 { z-index: 10; }
+
+.bg-white { background-color: white; }
+.bg-transparent { background-color: transparent; }
+
+.rounded { border-radius: 8px; }
+.rounded-lg { border-radius: 12px; }
+.rounded-xl { border-radius: 16px; }
+.rounded-2xl { border-radius: 24px; }
+.rounded-full { border-radius: 50%; }
+
+.shadow-sm { box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05); }
+.shadow { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); }
+.shadow-lg { box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15); }
+.shadow-xl { box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2); }
+
+.transition { transition: all 0.2s ease; }
+.hover-lift:hover { transform: translateY(-2px); }

--- a/client/styles/signup.css
+++ b/client/styles/signup.css
@@ -198,7 +198,7 @@
 }
 
 .speech-bubble-container::before {
-  content: '';
+  content: "";
   position: absolute;
   left: -8px;
   top: 50%;
@@ -431,12 +431,13 @@
 }
 
 @keyframes star-twinkle {
-  0%, 100% { 
-    opacity: 0.2; 
+  0%,
+  100% {
+    opacity: 0.2;
     transform: scale(1);
   }
-  50% { 
-    opacity: 0.8; 
+  50% {
+    opacity: 0.8;
     transform: scale(1.3);
   }
 }
@@ -769,62 +770,62 @@
   .hero-logo-text {
     font-size: 36px;
   }
-  
+
   .hero-title-text {
     font-size: 24px;
   }
-  
+
   .signup-chat-main-container {
     width: 95%;
     max-width: 380px;
   }
-  
+
   .companion-avatar-container {
     left: 8%;
     width: 70px;
     height: 70px;
   }
-  
+
   .speech-bubble-container {
     right: 25%;
     max-width: 140px;
     padding: 10px 12px;
   }
-  
+
   .signup-dual-sidebar {
     width: 60px;
     padding: 16px 0;
   }
-  
+
   .sidebar-toggle-button,
   .sidebar-icon-container {
     width: 36px;
     height: 36px;
   }
-  
+
   .content-section {
     padding: 24px 16px;
   }
-  
+
   .section-title {
     font-size: 18px;
   }
-  
+
   .latest-news-grid {
     grid-template-columns: repeat(2, 1fr);
   }
-  
+
   .parents-grid,
   .educators-grid,
   .experts-grid {
     grid-template-columns: 1fr;
   }
-  
+
   .header-actions-container {
     top: 16px;
     right: 16px;
   }
-  
+
   .header-action-button {
     padding: 6px 12px;
     font-size: 12px;
@@ -835,37 +836,37 @@
   .hero-logo-text {
     font-size: 28px;
   }
-  
+
   .hero-title-text {
     font-size: 20px;
   }
-  
+
   .signup-chat-input-container {
     width: 98%;
     padding: 0 8px;
   }
-  
+
   .content-section {
     padding: 20px 12px;
   }
-  
+
   .creativity-section {
     padding: 20px 12px;
   }
-  
+
   .plans-strip-container {
     padding: 12px 16px;
   }
-  
+
   .latest-news-grid {
     grid-template-columns: 1fr;
     gap: 12px;
   }
-  
+
   .signup-footer {
     padding: 32px 16px;
   }
-  
+
   .footer-content {
     grid-template-columns: 1fr;
     gap: 24px;
@@ -874,144 +875,388 @@
 
 /* ===== UTILITY CLASSES ===== */
 
-.text-center { text-align: center; }
-.text-left { text-align: left; }
-.text-right { text-align: right; }
+.text-center {
+  text-align: center;
+}
+.text-left {
+  text-align: left;
+}
+.text-right {
+  text-align: right;
+}
 
-.font-light { font-weight: 300; }
-.font-normal { font-weight: 400; }
-.font-medium { font-weight: 500; }
-.font-semibold { font-weight: 600; }
-.font-bold { font-weight: 700; }
-.font-extrabold { font-weight: 800; }
+.font-light {
+  font-weight: 300;
+}
+.font-normal {
+  font-weight: 400;
+}
+.font-medium {
+  font-weight: 500;
+}
+.font-semibold {
+  font-weight: 600;
+}
+.font-bold {
+  font-weight: 700;
+}
+.font-extrabold {
+  font-weight: 800;
+}
 
-.text-xs { font-size: 12px; }
-.text-sm { font-size: 14px; }
-.text-base { font-size: 16px; }
-.text-lg { font-size: 18px; }
-.text-xl { font-size: 20px; }
-.text-2xl { font-size: 24px; }
+.text-xs {
+  font-size: 12px;
+}
+.text-sm {
+  font-size: 14px;
+}
+.text-base {
+  font-size: 16px;
+}
+.text-lg {
+  font-size: 18px;
+}
+.text-xl {
+  font-size: 20px;
+}
+.text-2xl {
+  font-size: 24px;
+}
 
-.mb-0 { margin-bottom: 0; }
-.mb-1 { margin-bottom: 4px; }
-.mb-2 { margin-bottom: 8px; }
-.mb-3 { margin-bottom: 12px; }
-.mb-4 { margin-bottom: 16px; }
-.mb-6 { margin-bottom: 24px; }
-.mb-8 { margin-bottom: 32px; }
+.mb-0 {
+  margin-bottom: 0;
+}
+.mb-1 {
+  margin-bottom: 4px;
+}
+.mb-2 {
+  margin-bottom: 8px;
+}
+.mb-3 {
+  margin-bottom: 12px;
+}
+.mb-4 {
+  margin-bottom: 16px;
+}
+.mb-6 {
+  margin-bottom: 24px;
+}
+.mb-8 {
+  margin-bottom: 32px;
+}
 
-.p-0 { padding: 0; }
-.p-1 { padding: 4px; }
-.p-2 { padding: 8px; }
-.p-3 { padding: 12px; }
-.p-4 { padding: 16px; }
-.p-6 { padding: 24px; }
-.p-8 { padding: 32px; }
+.p-0 {
+  padding: 0;
+}
+.p-1 {
+  padding: 4px;
+}
+.p-2 {
+  padding: 8px;
+}
+.p-3 {
+  padding: 12px;
+}
+.p-4 {
+  padding: 16px;
+}
+.p-6 {
+  padding: 24px;
+}
+.p-8 {
+  padding: 32px;
+}
 
-.px-2 { padding-left: 8px; padding-right: 8px; }
-.px-4 { padding-left: 16px; padding-right: 16px; }
-.px-6 { padding-left: 24px; padding-right: 24px; }
-.px-8 { padding-left: 32px; padding-right: 32px; }
+.px-2 {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.px-4 {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.px-6 {
+  padding-left: 24px;
+  padding-right: 24px;
+}
+.px-8 {
+  padding-left: 32px;
+  padding-right: 32px;
+}
 
-.py-1 { padding-top: 4px; padding-bottom: 4px; }
-.py-2 { padding-top: 8px; padding-bottom: 8px; }
-.py-4 { padding-top: 16px; padding-bottom: 16px; }
-.py-6 { padding-top: 24px; padding-bottom: 24px; }
-.py-8 { padding-top: 32px; padding-bottom: 32px; }
+.py-1 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.py-2 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+.py-4 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+.py-6 {
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+.py-8 {
+  padding-top: 32px;
+  padding-bottom: 32px;
+}
 
-.w-full { width: 100%; }
-.h-full { height: 100%; }
-.h-screen { height: 100vh; }
+.w-full {
+  width: 100%;
+}
+.h-full {
+  height: 100%;
+}
+.h-screen {
+  height: 100vh;
+}
 
-.flex { display: flex; }
-.inline-flex { display: inline-flex; }
-.grid { display: grid; }
-.hidden { display: none; }
+.flex {
+  display: flex;
+}
+.inline-flex {
+  display: inline-flex;
+}
+.grid {
+  display: grid;
+}
+.hidden {
+  display: none;
+}
 
-.flex-col { flex-direction: column; }
-.items-center { align-items: center; }
-.items-start { align-items: flex-start; }
-.items-end { align-items: flex-end; }
-.justify-center { justify-content: center; }
-.justify-start { justify-content: flex-start; }
-.justify-end { justify-content: flex-end; }
-.justify-between { justify-content: space-between; }
+.flex-col {
+  flex-direction: column;
+}
+.items-center {
+  align-items: center;
+}
+.items-start {
+  align-items: flex-start;
+}
+.items-end {
+  align-items: flex-end;
+}
+.justify-center {
+  justify-content: center;
+}
+.justify-start {
+  justify-content: flex-start;
+}
+.justify-end {
+  justify-content: flex-end;
+}
+.justify-between {
+  justify-content: space-between;
+}
 
-.relative { position: relative; }
-.absolute { position: absolute; }
-.fixed { position: fixed; }
+.relative {
+  position: relative;
+}
+.absolute {
+  position: absolute;
+}
+.fixed {
+  position: fixed;
+}
 
-.inset-0 { top: 0; right: 0; bottom: 0; left: 0; }
-.top-0 { top: 0; }
-.right-0 { right: 0; }
-.bottom-0 { bottom: 0; }
-.left-0 { left: 0; }
+.inset-0 {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+.top-0 {
+  top: 0;
+}
+.right-0 {
+  right: 0;
+}
+.bottom-0 {
+  bottom: 0;
+}
+.left-0 {
+  left: 0;
+}
 
-.z-0 { z-index: 0; }
-.z-10 { z-index: 10; }
-.z-20 { z-index: 20; }
-.z-30 { z-index: 30; }
-.z-40 { z-index: 40; }
-.z-50 { z-index: 50; }
+.z-0 {
+  z-index: 0;
+}
+.z-10 {
+  z-index: 10;
+}
+.z-20 {
+  z-index: 20;
+}
+.z-30 {
+  z-index: 30;
+}
+.z-40 {
+  z-index: 40;
+}
+.z-50 {
+  z-index: 50;
+}
 
-.overflow-hidden { overflow: hidden; }
-.overflow-y-auto { overflow-y: auto; }
+.overflow-hidden {
+  overflow: hidden;
+}
+.overflow-y-auto {
+  overflow-y: auto;
+}
 
-.rounded { border-radius: 4px; }
-.rounded-lg { border-radius: 8px; }
-.rounded-xl { border-radius: 12px; }
-.rounded-2xl { border-radius: 16px; }
-.rounded-full { border-radius: 50%; }
+.rounded {
+  border-radius: 4px;
+}
+.rounded-lg {
+  border-radius: 8px;
+}
+.rounded-xl {
+  border-radius: 12px;
+}
+.rounded-2xl {
+  border-radius: 16px;
+}
+.rounded-full {
+  border-radius: 50%;
+}
 
-.border { border: 1px solid #e5e7eb; }
-.border-0 { border: none; }
+.border {
+  border: 1px solid #e5e7eb;
+}
+.border-0 {
+  border: none;
+}
 
-.bg-white { background-color: white; }
-.bg-gray-100 { background-color: #f3f4f6; }
-.bg-gray-200 { background-color: #e5e7eb; }
-.bg-purple-100 { background-color: #ede9fe; }
+.bg-white {
+  background-color: white;
+}
+.bg-gray-100 {
+  background-color: #f3f4f6;
+}
+.bg-gray-200 {
+  background-color: #e5e7eb;
+}
+.bg-purple-100 {
+  background-color: #ede9fe;
+}
 
-.text-gray-500 { color: #6b7280; }
-.text-gray-600 { color: #4b5563; }
-.text-gray-700 { color: #374151; }
-.text-gray-900 { color: #111827; }
-.text-purple-600 { color: #7c3aed; }
-.text-purple-800 { color: #5b21b6; }
+.text-gray-500 {
+  color: #6b7280;
+}
+.text-gray-600 {
+  color: #4b5563;
+}
+.text-gray-700 {
+  color: #374151;
+}
+.text-gray-900 {
+  color: #111827;
+}
+.text-purple-600 {
+  color: #7c3aed;
+}
+.text-purple-800 {
+  color: #5b21b6;
+}
 
-.shadow { box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1); }
-.shadow-lg { box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1); }
-.shadow-xl { box-shadow: 0 20px 25px rgba(0, 0, 0, 0.1); }
+.shadow {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+.shadow-lg {
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
+}
+.shadow-xl {
+  box-shadow: 0 20px 25px rgba(0, 0, 0, 0.1);
+}
 
-.transition { transition: all 0.15s ease-in-out; }
-.transform { transform: translateZ(0); }
+.transition {
+  transition: all 0.15s ease-in-out;
+}
+.transform {
+  transform: translateZ(0);
+}
 
-.hover\:text-purple-700:hover { color: #6d28d9; }
-.hover\:bg-gray-100:hover { background-color: #f3f4f6; }
+.hover\:text-purple-700:hover {
+  color: #6d28d9;
+}
+.hover\:bg-gray-100:hover {
+  background-color: #f3f4f6;
+}
 
-.cursor-pointer { cursor: pointer; }
-.select-none { user-select: none; }
+.cursor-pointer {
+  cursor: pointer;
+}
+.select-none {
+  user-select: none;
+}
 
-.gap-1 { gap: 4px; }
-.gap-2 { gap: 8px; }
-.gap-3 { gap: 12px; }
-.gap-4 { gap: 16px; }
-.gap-6 { gap: 24px; }
+.gap-1 {
+  gap: 4px;
+}
+.gap-2 {
+  gap: 8px;
+}
+.gap-3 {
+  gap: 12px;
+}
+.gap-4 {
+  gap: 16px;
+}
+.gap-6 {
+  gap: 24px;
+}
 
-.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
 
-.max-w-md { max-width: 448px; }
-.max-w-lg { max-width: 512px; }
-.max-w-xl { max-width: 576px; }
-.max-w-2xl { max-width: 672px; }
-.max-w-4xl { max-width: 896px; }
+.max-w-md {
+  max-width: 448px;
+}
+.max-w-lg {
+  max-width: 512px;
+}
+.max-w-xl {
+  max-width: 576px;
+}
+.max-w-2xl {
+  max-width: 672px;
+}
+.max-w-4xl {
+  max-width: 896px;
+}
 
-.mx-1 { margin-left: 4px; margin-right: 4px; }
-.mx-auto { margin-left: auto; margin-right: auto; }
+.mx-1 {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
 
-.line-height-1 { line-height: 1; }
-.line-height-1-2 { line-height: 1.2; }
-.line-height-1-4 { line-height: 1.4; }
-.line-height-1-6 { line-height: 1.6; }
+.line-height-1 {
+  line-height: 1;
+}
+.line-height-1-2 {
+  line-height: 1.2;
+}
+.line-height-1-4 {
+  line-height: 1.4;
+}
+.line-height-1-6 {
+  line-height: 1.6;
+}

--- a/client/styles/signup.css
+++ b/client/styles/signup.css
@@ -1,0 +1,1017 @@
+/* ===== ORIGINAL SIGNUP PAGE STYLES ===== */
+
+/* Base Layout */
+.signup-page {
+  position: relative;
+}
+
+.signup-hero-container {
+  position: relative;
+  z-index: 0;
+}
+
+.signup-content-container {
+  position: relative;
+  z-index: 10;
+  background-color: white;
+}
+
+.signup-footer-container {
+  position: relative;
+  z-index: 10;
+}
+
+/* ===== HERO SECTION STYLES ===== */
+
+.hero-section-main {
+  position: relative;
+  height: 100vh;
+  width: 100%;
+  overflow: hidden;
+}
+
+.hero-background-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center center;
+  background-repeat: no-repeat;
+  z-index: 0;
+}
+
+.hero-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1;
+}
+
+.hero-content-wrapper {
+  position: relative;
+  z-index: 2;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+}
+
+.hero-logo-text {
+  font-size: 48px;
+  font-weight: 800;
+  color: white;
+  text-align: center;
+  margin-bottom: 16px;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.hero-title-text {
+  font-size: 32px;
+  font-weight: 700;
+  color: white;
+  text-align: center;
+  margin-bottom: 32px;
+  line-height: 1.2;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+/* ===== CHAT CONTAINER STYLES ===== */
+
+.signup-chat-main-container {
+  position: absolute;
+  left: 50%;
+  top: 45%;
+  transform: translate(-50%, -50%);
+  width: 90%;
+  max-width: 480px;
+  background-color: white;
+  border-radius: 24px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  z-index: 3;
+}
+
+.chat-header-section {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  padding: 20px;
+  text-align: center;
+}
+
+.chat-header-title {
+  color: white;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.chat-messages-container {
+  padding: 24px;
+  min-height: 180px;
+  max-height: 300px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-message-item {
+  padding: 10px 14px;
+  border-radius: 16px;
+  max-width: 85%;
+  word-wrap: break-word;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.chat-message-ai {
+  background-color: #f3f4f6;
+  color: #374151;
+  align-self: flex-start;
+}
+
+.chat-message-kid {
+  background-color: #667eea;
+  color: white;
+  align-self: flex-end;
+}
+
+.chat-message-system {
+  background-color: #fef3c7;
+  color: #92400e;
+  align-self: center;
+  font-size: 12px;
+  font-style: italic;
+}
+
+/* ===== COMPANION AVATAR STYLES ===== */
+
+.companion-avatar-container {
+  position: absolute;
+  left: 12%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 90px;
+  height: 90px;
+  z-index: 4;
+}
+
+.companion-avatar-image {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 3px solid white;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+  object-fit: cover;
+}
+
+.companion-lottie-container {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 3px solid white;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+/* ===== SPEECH BUBBLE STYLES ===== */
+
+.speech-bubble-container {
+  position: absolute;
+  right: 28%;
+  top: 35%;
+  transform: translateY(-50%);
+  background-color: white;
+  border-radius: 16px;
+  padding: 12px 16px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  max-width: 180px;
+  z-index: 4;
+}
+
+.speech-bubble-container::before {
+  content: '';
+  position: absolute;
+  left: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-right: 8px solid white;
+}
+
+.speech-bubble-text {
+  font-size: 13px;
+  color: #374151;
+  margin: 0;
+  line-height: 1.3;
+}
+
+/* ===== CHAT INPUT STYLES ===== */
+
+.signup-chat-input-container {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 95%;
+  max-width: 600px;
+  z-index: 5;
+  padding: 0 16px;
+}
+
+.chat-input-wrapper {
+  background-color: white;
+  border-radius: 50px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  padding: 8px 20px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 2px solid #f3f4f6;
+}
+
+.chat-input-field {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  padding: 12px 0;
+  background: transparent;
+  color: #374151;
+}
+
+.chat-input-field::placeholder {
+  color: #9ca3af;
+}
+
+.chat-input-mic-button,
+.chat-input-send-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chat-input-mic-button {
+  background-color: #f3f4f6;
+  color: #6b7280;
+}
+
+.chat-input-mic-button:hover {
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+.chat-input-send-button {
+  background-color: #667eea;
+  color: white;
+}
+
+.chat-input-send-button:hover {
+  background-color: #5a67d8;
+  transform: translateY(-1px);
+}
+
+.chat-input-send-button:disabled {
+  background-color: #d1d5db;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* ===== DUAL SIDEBAR STYLES ===== */
+
+.signup-dual-sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 70px;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 0;
+  gap: 16px;
+}
+
+.sidebar-toggle-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: #6b7280;
+}
+
+.sidebar-toggle-button:hover {
+  background-color: #667eea;
+  color: white;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.sidebar-icon-container {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background-color: #f9fafb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: #6b7280;
+}
+
+.sidebar-icon-container:hover {
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+/* ===== HEADER ACTIONS STYLES ===== */
+
+.header-actions-container {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  z-index: 7;
+  display: flex;
+  gap: 12px;
+}
+
+.header-action-button {
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background-color: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(8px);
+  color: white;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.header-action-button:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.header-login-button {
+  background-color: transparent;
+}
+
+.header-signup-button {
+  background-color: #667eea;
+  border-color: #667eea;
+}
+
+.header-signup-button:hover {
+  background-color: #5a67d8;
+}
+
+/* ===== DECORATIVE STARS STYLES ===== */
+
+.decorative-stars-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 1;
+  overflow: hidden;
+}
+
+.decorative-star {
+  position: absolute;
+  background-color: white;
+  border-radius: 50%;
+  opacity: 0.6;
+  animation: star-twinkle 4s infinite ease-in-out;
+}
+
+.star-size-small {
+  width: 2px;
+  height: 2px;
+}
+
+.star-size-medium {
+  width: 3px;
+  height: 3px;
+}
+
+.star-size-large {
+  width: 4px;
+  height: 4px;
+}
+
+@keyframes star-twinkle {
+  0%, 100% { 
+    opacity: 0.2; 
+    transform: scale(1);
+  }
+  50% { 
+    opacity: 0.8; 
+    transform: scale(1.3);
+  }
+}
+
+/* ===== CONTENT SECTIONS STYLES ===== */
+
+.content-section {
+  padding: 32px 32px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.section-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.section-view-all-link {
+  color: #7c3aed;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.section-view-all-link:hover {
+  color: #6d28d9;
+}
+
+/* ===== CREATIVITY SECTION STYLES ===== */
+
+.creativity-section {
+  padding: 32px 32px;
+  text-align: center;
+}
+
+.creativity-text-main {
+  color: #374151;
+  margin-bottom: 8px;
+}
+
+.creativity-text-bold {
+  font-weight: 600;
+}
+
+.creativity-ai-badge {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 4px;
+  padding: 4px 8px;
+  background-color: #ede9fe;
+  color: #7c3aed;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.creativity-text-secondary {
+  color: #6b7280;
+}
+
+/* ===== PLANS STRIP STYLES ===== */
+
+.plans-strip-container {
+  background-color: #fef3c7;
+  padding: 16px 32px;
+  text-align: center;
+}
+
+.plans-strip-text {
+  color: #92400e;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.plans-strip-button {
+  background-color: #f59e0b;
+  color: white;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: none;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.plans-strip-button:hover {
+  background-color: #d97706;
+}
+
+/* ===== CARD STYLES ===== */
+
+.content-card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+}
+
+.content-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.card-content {
+  padding: 12px;
+}
+
+.card-image-placeholder {
+  width: 100%;
+  height: 80px;
+  background-color: #e5e7eb;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.card-title {
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 4px;
+}
+
+.card-date {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+/* ===== LATEST NEWS SECTION STYLES ===== */
+
+.latest-news-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.news-card {
+  background-color: #f9fafb;
+  border: none;
+}
+
+@media (min-width: 768px) {
+  .latest-news-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+/* ===== INTRODUCING SECTION STYLES ===== */
+
+.introducing-section {
+  padding: 32px;
+  text-align: center;
+}
+
+.introducing-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 16px;
+}
+
+.introducing-description {
+  font-size: 16px;
+  color: #6b7280;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* ===== PARENTS SECTION STYLES ===== */
+
+.parents-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+}
+
+.parents-card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+}
+
+.parents-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+/* ===== EDUCATORS SECTION STYLES ===== */
+
+.educators-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+}
+
+.educators-card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+}
+
+.educators-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+/* ===== EXPERTS SECTION STYLES ===== */
+
+.experts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+}
+
+.experts-card {
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+}
+
+.experts-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+/* ===== FOOTER STYLES ===== */
+
+.signup-footer {
+  background-color: #111827;
+  color: white;
+  padding: 40px 32px;
+}
+
+.footer-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 32px;
+}
+
+.footer-section-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.footer-link {
+  color: #d1d5db;
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 2;
+  transition: color 0.2s ease;
+}
+
+.footer-link:hover {
+  color: white;
+}
+
+.footer-bottom {
+  border-top: 1px solid #374151;
+  padding-top: 24px;
+  margin-top: 32px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
+/* ===== MODAL STYLES ===== */
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  background-color: white;
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 500px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.modal-close-button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: #f3f4f6;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.modal-close-button:hover {
+  background-color: #e5e7eb;
+}
+
+/* ===== RESPONSIVE STYLES ===== */
+
+@media (max-width: 768px) {
+  .hero-logo-text {
+    font-size: 36px;
+  }
+  
+  .hero-title-text {
+    font-size: 24px;
+  }
+  
+  .signup-chat-main-container {
+    width: 95%;
+    max-width: 380px;
+  }
+  
+  .companion-avatar-container {
+    left: 8%;
+    width: 70px;
+    height: 70px;
+  }
+  
+  .speech-bubble-container {
+    right: 25%;
+    max-width: 140px;
+    padding: 10px 12px;
+  }
+  
+  .signup-dual-sidebar {
+    width: 60px;
+    padding: 16px 0;
+  }
+  
+  .sidebar-toggle-button,
+  .sidebar-icon-container {
+    width: 36px;
+    height: 36px;
+  }
+  
+  .content-section {
+    padding: 24px 16px;
+  }
+  
+  .section-title {
+    font-size: 18px;
+  }
+  
+  .latest-news-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  
+  .parents-grid,
+  .educators-grid,
+  .experts-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .header-actions-container {
+    top: 16px;
+    right: 16px;
+  }
+  
+  .header-action-button {
+    padding: 6px 12px;
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-logo-text {
+    font-size: 28px;
+  }
+  
+  .hero-title-text {
+    font-size: 20px;
+  }
+  
+  .signup-chat-input-container {
+    width: 98%;
+    padding: 0 8px;
+  }
+  
+  .content-section {
+    padding: 20px 12px;
+  }
+  
+  .creativity-section {
+    padding: 20px 12px;
+  }
+  
+  .plans-strip-container {
+    padding: 12px 16px;
+  }
+  
+  .latest-news-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  
+  .signup-footer {
+    padding: 32px 16px;
+  }
+  
+  .footer-content {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+
+/* ===== UTILITY CLASSES ===== */
+
+.text-center { text-align: center; }
+.text-left { text-align: left; }
+.text-right { text-align: right; }
+
+.font-light { font-weight: 300; }
+.font-normal { font-weight: 400; }
+.font-medium { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.font-bold { font-weight: 700; }
+.font-extrabold { font-weight: 800; }
+
+.text-xs { font-size: 12px; }
+.text-sm { font-size: 14px; }
+.text-base { font-size: 16px; }
+.text-lg { font-size: 18px; }
+.text-xl { font-size: 20px; }
+.text-2xl { font-size: 24px; }
+
+.mb-0 { margin-bottom: 0; }
+.mb-1 { margin-bottom: 4px; }
+.mb-2 { margin-bottom: 8px; }
+.mb-3 { margin-bottom: 12px; }
+.mb-4 { margin-bottom: 16px; }
+.mb-6 { margin-bottom: 24px; }
+.mb-8 { margin-bottom: 32px; }
+
+.p-0 { padding: 0; }
+.p-1 { padding: 4px; }
+.p-2 { padding: 8px; }
+.p-3 { padding: 12px; }
+.p-4 { padding: 16px; }
+.p-6 { padding: 24px; }
+.p-8 { padding: 32px; }
+
+.px-2 { padding-left: 8px; padding-right: 8px; }
+.px-4 { padding-left: 16px; padding-right: 16px; }
+.px-6 { padding-left: 24px; padding-right: 24px; }
+.px-8 { padding-left: 32px; padding-right: 32px; }
+
+.py-1 { padding-top: 4px; padding-bottom: 4px; }
+.py-2 { padding-top: 8px; padding-bottom: 8px; }
+.py-4 { padding-top: 16px; padding-bottom: 16px; }
+.py-6 { padding-top: 24px; padding-bottom: 24px; }
+.py-8 { padding-top: 32px; padding-bottom: 32px; }
+
+.w-full { width: 100%; }
+.h-full { height: 100%; }
+.h-screen { height: 100vh; }
+
+.flex { display: flex; }
+.inline-flex { display: inline-flex; }
+.grid { display: grid; }
+.hidden { display: none; }
+
+.flex-col { flex-direction: column; }
+.items-center { align-items: center; }
+.items-start { align-items: flex-start; }
+.items-end { align-items: flex-end; }
+.justify-center { justify-content: center; }
+.justify-start { justify-content: flex-start; }
+.justify-end { justify-content: flex-end; }
+.justify-between { justify-content: space-between; }
+
+.relative { position: relative; }
+.absolute { position: absolute; }
+.fixed { position: fixed; }
+
+.inset-0 { top: 0; right: 0; bottom: 0; left: 0; }
+.top-0 { top: 0; }
+.right-0 { right: 0; }
+.bottom-0 { bottom: 0; }
+.left-0 { left: 0; }
+
+.z-0 { z-index: 0; }
+.z-10 { z-index: 10; }
+.z-20 { z-index: 20; }
+.z-30 { z-index: 30; }
+.z-40 { z-index: 40; }
+.z-50 { z-index: 50; }
+
+.overflow-hidden { overflow: hidden; }
+.overflow-y-auto { overflow-y: auto; }
+
+.rounded { border-radius: 4px; }
+.rounded-lg { border-radius: 8px; }
+.rounded-xl { border-radius: 12px; }
+.rounded-2xl { border-radius: 16px; }
+.rounded-full { border-radius: 50%; }
+
+.border { border: 1px solid #e5e7eb; }
+.border-0 { border: none; }
+
+.bg-white { background-color: white; }
+.bg-gray-100 { background-color: #f3f4f6; }
+.bg-gray-200 { background-color: #e5e7eb; }
+.bg-purple-100 { background-color: #ede9fe; }
+
+.text-gray-500 { color: #6b7280; }
+.text-gray-600 { color: #4b5563; }
+.text-gray-700 { color: #374151; }
+.text-gray-900 { color: #111827; }
+.text-purple-600 { color: #7c3aed; }
+.text-purple-800 { color: #5b21b6; }
+
+.shadow { box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1); }
+.shadow-lg { box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1); }
+.shadow-xl { box-shadow: 0 20px 25px rgba(0, 0, 0, 0.1); }
+
+.transition { transition: all 0.15s ease-in-out; }
+.transform { transform: translateZ(0); }
+
+.hover\:text-purple-700:hover { color: #6d28d9; }
+.hover\:bg-gray-100:hover { background-color: #f3f4f6; }
+
+.cursor-pointer { cursor: pointer; }
+.select-none { user-select: none; }
+
+.gap-1 { gap: 4px; }
+.gap-2 { gap: 8px; }
+.gap-3 { gap: 12px; }
+.gap-4 { gap: 16px; }
+.gap-6 { gap: 24px; }
+
+.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+
+.max-w-md { max-width: 448px; }
+.max-w-lg { max-width: 512px; }
+.max-w-xl { max-width: 576px; }
+.max-w-2xl { max-width: 672px; }
+.max-w-4xl { max-width: 896px; }
+
+.mx-1 { margin-left: 4px; margin-right: 4px; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+
+.line-height-1 { line-height: 1; }
+.line-height-1-2 { line-height: 1.2; }
+.line-height-1-4 { line-height: 1.4; }
+.line-height-1-6 { line-height: 1.6; }


### PR DESCRIPTION
## Purpose

Based on user feedback, the companion placement needed to be repositioned to the left side of the screen as shown in a reference screenshot. Users reported issues with the current structure where the companion and speech bubble were not shifting properly to the desired layout.

## Code changes

- **Added new SignupMui page**: Created `/pages/SignupMui` component and added route `/signup-mui` to App.tsx
- **Created MuiCompanionSelectionModal component**: New modal component featuring:
  - Circular layout positioning for 6 companions (Letsgo, Rushmore, Uni, Cody, Doma, Rooty) using trigonometric calculations
  - Material-UI components (Modal, Box, IconButton, Chip, Typography)
  - Hover effects with companion descriptions
  - Center close button with red styling
  - Responsive design with backdrop blur effects
- **Added comprehensive CSS styles**: Extensive styling for signup components including hero sections, sidebars, content sections, modals, and responsive breakpoints

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4d57a00662854b51bd447fdcf09e0bb2/spark-works)

👀 [Preview Link](https://4d57a00662854b51bd447fdcf09e0bb2-spark-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4d57a00662854b51bd447fdcf09e0bb2</projectId>-->
<!--<branchName>spark-works</branchName>-->